### PR TITLE
doc(builder.go,git.go,server.go,utils.go): adding proper godoc

### DIFF
--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -1,8 +1,6 @@
-// Package builder provides libraries for the Deis builder.
+// Package pkg provides common libraries for the Deis builder.
 //
 // The Deis builder is responsible for packaging Docker images for consumers.
-//
-// The builder/cli package contains command line clients for this library.
 package pkg
 
 import (

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// PrereceiveHookTmpl is a pre-receive hook.
+// PrereceiveHookTpl is a pre-receive hook.
 //
 // This is overridable. The following template variables are passed into it:
 //

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -31,7 +31,7 @@ const (
 	ServerConfig string = "ssh.ServerConfig"
 )
 
-// PrereceiveHookTmpl is a pre-receive hook.
+// PrereceiveHookTpl is a pre-receive hook.
 const PrereceiveHookTpl = `#!/bin/bash
 strip_remote_prefix() {
     stdbuf -i0 -o0 -e0 sed "s/^/"$'\e[1G'"/"

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -110,6 +110,9 @@ func ParseControllerConfig(bytes []byte) ([]string, error) {
 	}
 	return retVal, nil
 }
+
+// Extract opens sourcefile and, if it has a '.gz' extension, unzips it using a gzip.Reader.
+// then, it untars it using a tar.Reader
 func Extract(sourcefile string) (err error) {
 
 	file, err := os.Open(sourcefile)


### PR DESCRIPTION
replaces part of #9 