### PR TITLE
fix(*): fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,15 @@
-language: go
-go:
-  - 1.5.1
-env:
-  - GO15VENDOREXPERIMENT=1
+language: generic
 branches:
   only:
     - master
 cache:
   directories:
-    - $GOPATH/src/github.com/deis/builder/vendor
+    - vendor
 services:
   - docker
 sudo: required
-before_install:
-  - wget "https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz"
-  - sudo tar -vxz -C /usr/local/bin --strip=1 -f glide-0.7.2-linux-amd64.tar.gz
 install:
-  - GLIDE_HOME=/home/travis/.glide make bootstrap
+  - make bootstrap
 script:
   - make test
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ SHORT_NAME ?= builder
 # Enable vendor/ directory support.
 export GO15VENDOREXPERIMENT=1
 
+# dockerized development environment variables
+REPO_PATH := github.com/deis/${SHORT_NAME}
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.2.0
+DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
+DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
+DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
+
 # SemVer with build information is defined in the SemVer 2 spec, but Docker
 # doesn't allow +, so we use -.
 VERSION ?= git-$(shell git rev-parse --short HEAD)
@@ -27,25 +34,25 @@ all:
 	@echo "Use a Makefile to control top-level building of the project."
 
 bootstrap:
-	glide up
+	${DEV_ENV_CMD} glide up
 
 # This illustrates a two-stage Docker build. docker-compile runs inside of
 # the Docker environment. Other alternatives are cross-compiling, doing
 # the build as a `docker build`.
 build:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0  go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/builder boot.go || exit 1
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0  go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/fetcher fetcher/fetcher.go || exit 1
+	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/builder boot.go || exit 1
+	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/fetcher fetcher/fetcher.go || exit 1
 	@$(call check-static-binary,$(BINARY_DEST_DIR)/builder)
 	@$(call check-static-binary,$(BINARY_DEST_DIR)/fetcher)
 	for i in $(BINARIES); do \
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i pkg/src/$$i.go || exit 1; \
+		${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i pkg/src/$$i.go || exit 1; \
 	done
 	@for i in $(BINARIES); do \
 		$(call check-static-binary,$(BINARY_DEST_DIR)/$$i); \
 	done
 
 test:
-	go test ./pkg && go test ./pkg/confd && go test ./pkg/env && go test ./pkg/etcd && go test ./pkg/git && go test ./pkg/sshd
+	${DEV_ENV_CMD} go test ./pkg && go test ./pkg/confd && go test ./pkg/env && go test ./pkg/etcd && go test ./pkg/git && go test ./pkg/sshd
 
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,12 @@ build:
 	done
 
 test:
-	${DEV_ENV_CMD} go test ./pkg && go test ./pkg/confd && go test ./pkg/env && go test ./pkg/etcd && go test ./pkg/git && go test ./pkg/sshd
+	${DEV_ENV_CMD} go test ./pkg && \
+	${DEV_ENV_CMD} go test ./pkg/confd && \
+	${DEV_ENV_CMD} go test ./pkg/env && \
+	${DEV_ENV_CMD} go test ./pkg/etcd && \
+	${DEV_ENV_CMD} go test ./pkg/git && \
+	${DEV_ENV_CMD} go test ./pkg/sshd
 
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")" || exit 1
 
 export IMAGE_PREFIX=deisci VERSION=v2-alpha
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-DEIS_REGISTRY='' make -C .. docker-build docker-push
+DEIS_REGISTRY='' make -C .. build docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push
+DEIS_REGISTRY=quay.io/ make -C .. build docker-build docker-push


### PR DESCRIPTION
There are two semantic changes in this PR, both involving the travis build. See below for details.

- make travis run the `build` target before `docker-build` so that necessary binaries get copied into docker image (no more `/entrypoint.sh: line 5: exec: builder: not found` errors on the `quay.io/deisci/builder:v2-alpha` image)
- also switch to using the dev image to run `go` and `glide`. this change allows us to greatly simplify the `.travis.yml` file, including using `language: generic`

Fixes #23 

cc/ @mboersma