### PR TITLE
fix(deis-builder-rc.yaml): fix indentation on deis-builder RC

### DIFF
--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -30,19 +30,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-      volumeMounts:
+          volumeMounts:
+            - name: minio-user
+              mountPath: /var/run/secrets/object/store
+              readOnly: true
+            # not currently running minio with SSL support. see https://github.com/deis/minio/pull/22 for more detail
+            # - name: minio-ssl
+            #   mountPath: /var/run/secrets/object/ssl
+            #   readOnly: true
+      volumes:
         - name: minio-user
-          mountPath: /var/run/secrets/object/store
-          readOnly: true
+          secret:
+            secretName: minio-user
         # not currently running minio with SSL support. see https://github.com/deis/minio/pull/22 for more detail
         # - name: minio-ssl
-        #   mountPath: /var/run/secrets/object/ssl
-        #   readOnly: true
-  volumes:
-    - name: minio-user
-      secret:
-        secretName: minio-user
-    # not currently running minio with SSL support. see https://github.com/deis/minio/pull/22 for more detail
-    # - name: minio-ssl
-    #   secret:
-    #     secretName: minio-ssl
+        #   secret:
+        #     secretName: minio-ssl


### PR DESCRIPTION
not marking showstopper because it's correct in the [helm chart](https://github.com/deis/charts/blob/master/deis/manifests/deis-builder-rc.yaml)