### PR TITLE
fix(deis-slugbuilder.yaml): use repo_name instead of deis-slugbuilder

### DIFF
--- a/rootfs/etc/deis-slugbuilder.yaml
+++ b/rootfs/etc/deis-slugbuilder.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: deis-slugbuilder
+  name: repo_name
   labels:
     heritage: deis
     version: v2-alpha


### PR DESCRIPTION
so the builder script can replace it with the git sha, and no collisions occur

Fixes #41 