### PR TITLE
fix(Dockerfile,deis-builder-rc.yaml): add DOCKERIMAGE env var

### DIFF
--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -23,9 +23,6 @@ spec:
           env:
             - name: "EXTERNAL_PORT"
               value: "2223"
-            # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
-            - name: "DOCKERIMAGE"
-              value: "1"
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -32,6 +32,8 @@ RUN mkdir -p /var/run/sshd && rm -rf /etc/ssh/ssh_host*
 # install git and configure gituser
 ENV GITHOME /home/git
 ENV GITUSER git
+# this is so the minio client (https://github.com/minio/mc) works properly
+ENV DOCKERIMAGE=1
 RUN mkdir /apps
 RUN adduser -D -h $GITHOME $GITUSER
 RUN mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh


### PR DESCRIPTION
We have to set it so the minio client (https://github.com/minio/mc) works properly. Also, we can remove it in the RC manifest because it’s already in the Dockerfile.

The env var can also be removed from [deis/charts](https://github.com/deis/charts/blob/master/deis/manifests/deis-builder-rc.yaml#L30) once this is merged, but since it's redundant it's not a hard requirement for this PR.