### PR TITLE
feat(builder): remove extra git archive tar

### DIFF
--- a/rootfs/etc/confd/templates/builder
+++ b/rootfs/etc/confd/templates/builder
@@ -113,7 +113,6 @@ else
   fi
 fi
 
-git archive --format=tar.gz ${GIT_SHA} > ${APP_NAME}.tar.gz
 
 HTTP_PREFIX="http"
 REMOTE_STORAGE="0"


### PR DESCRIPTION
in builder script we are doing ```git archive --format=tar.gz ${GIT_SHA} > ${APP_NAME}.tar.gz``` twice which is not necessary. Removing the second command