### PR TITLE
ref(build.go): pulling slugbuilder storage params out

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -60,7 +60,7 @@ func build(conf *Config, s3Client *s3.S3, builderKey, rawGitSha string) error {
 	}
 	tmpDir := os.TempDir()
 
-	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client, appName, slugName, gitSha)
+	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client.Endpoint, appName, slugName, gitSha)
 
 	// Get the application config from the controller, so we can check for a custom buildpack URL
 	appConf, err := getAppConfig(conf, builderKey, conf.Username, appName)

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -163,6 +163,8 @@ func build(conf *Config, s3Client *s3.S3, builderKey, rawGitSha string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s for read (%s)", appTgz, err)
 	}
+
+	log.Debug("Uploading tar to %s/%s/%s", s3Client.Endpoint, bucketName, slugBuilderInfo.TarKey)
 	if err := storage.UploadObject(s3Client, bucketName, slugBuilderInfo.TarKey, appTgzReader); err != nil {
 		return fmt.Errorf("uploading %s to %s/%s (%v)", absAppTgz, bucketName, slugBuilderInfo.TarKey, err)
 	}

--- a/pkg/gitreceive/git/sha.go
+++ b/pkg/gitreceive/git/sha.go
@@ -22,13 +22,16 @@ func (e ErrInvalidGitSha) Error() string {
 }
 
 type SHA struct {
-	Full  string
-	Short string
+	full  string
+	short string
 }
 
 func NewSha(rawSha string) (*SHA, error) {
 	if !shaRegex.Match([]byte(rawSha)) {
 		return nil, ErrInvalidGitSha{sha: rawSha}
 	}
-	return &SHA{Full: rawSha, Short: rawSha[0:8]}, nil
+	return &SHA{full: rawSha, short: rawSha[0:8]}, nil
 }
+
+func (s SHA) Full() string  { return s.full }
+func (s SHA) Short() string { return s.short }

--- a/pkg/gitreceive/git/sha.go
+++ b/pkg/gitreceive/git/sha.go
@@ -1,0 +1,31 @@
+package git
+
+import (
+	"fmt"
+)
+
+const (
+	// this constant represents the length of a shortened git sha - 8 characters long
+	shortShaIdx = 8
+	fullShaLen  = 40
+)
+
+type ErrGitShaTooShort struct {
+	sha string
+}
+
+func (e ErrGitShaTooShort) Error() string {
+	return fmt.Sprintf("git sha %s was too short", e.sha)
+}
+
+type SHA struct {
+	Full  string
+	Short string
+}
+
+func NewSha(rawSha string) (*SHA, error) {
+	if len(rawSha) < fullShaLen {
+		return nil, ErrGitShaTooShort{sha: rawSha}
+	}
+	return &SHA{Full: rawSha, Short: rawSha[0:8]}, nil
+}

--- a/pkg/gitreceive/git/sha.go
+++ b/pkg/gitreceive/git/sha.go
@@ -8,7 +8,6 @@ import (
 const (
 	// this constant represents the length of a shortened git sha - 8 characters long
 	shortShaIdx = 8
-	fullShaLen  = 40
 )
 
 var shaRegex = regexp.MustCompile(`^[\da-f]{40}$`)

--- a/pkg/gitreceive/git/sha.go
+++ b/pkg/gitreceive/git/sha.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"regexp"
 )
 
 const (
@@ -10,12 +11,14 @@ const (
 	fullShaLen  = 40
 )
 
-type ErrGitShaTooShort struct {
+var shaRegex = regexp.MustCompile(`^[\da-f]{40}$`)
+
+type ErrInvalidGitSha struct {
 	sha string
 }
 
-func (e ErrGitShaTooShort) Error() string {
-	return fmt.Sprintf("git sha %s was too short", e.sha)
+func (e ErrInvalidGitSha) Error() string {
+	return fmt.Sprintf("git sha %s was invalid", e.sha)
 }
 
 type SHA struct {
@@ -24,8 +27,8 @@ type SHA struct {
 }
 
 func NewSha(rawSha string) (*SHA, error) {
-	if len(rawSha) < fullShaLen {
-		return nil, ErrGitShaTooShort{sha: rawSha}
+	if !shaRegex.Match([]byte(rawSha)) {
+		return nil, ErrInvalidGitSha{sha: rawSha}
 	}
 	return &SHA{Full: rawSha, Short: rawSha[0:8]}, nil
 }

--- a/pkg/gitreceive/git/sha.go
+++ b/pkg/gitreceive/git/sha.go
@@ -27,7 +27,7 @@ type SHA struct {
 }
 
 func NewSha(rawSha string) (*SHA, error) {
-	if !shaRegex.Match([]byte(rawSha)) {
+	if !shaRegex.MatchString(rawSha) {
 		return nil, ErrInvalidGitSha{sha: rawSha}
 	}
 	return &SHA{full: rawSha, short: rawSha[0:8]}, nil

--- a/pkg/gitreceive/git/sha_test.go
+++ b/pkg/gitreceive/git/sha_test.go
@@ -34,11 +34,11 @@ func TestNewSha(t *testing.T) {
 			t.Errorf("expected no error for sha %s (#%d), got %s", shaStr, i, err)
 			continue
 		}
-		if sha.Full != shaStr {
-			t.Errorf("expected full sha string to be %s, got %s", shaStr, sha.Full)
+		if sha.Full() != shaStr {
+			t.Errorf("expected full sha string to be %s, got %s", shaStr, sha.Full())
 		}
-		if sha.Short != shaStr[0:8] {
-			t.Errorf("expected short sha to be first 8 characters of %s, got %s", shaStr, sha.Short)
+		if sha.Short() != shaStr[0:8] {
+			t.Errorf("expected short sha to be first 8 characters of %s, got %s", shaStr, sha.Short())
 		}
 	}
 }

--- a/pkg/gitreceive/git/sha_test.go
+++ b/pkg/gitreceive/git/sha_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestShaTooShort(t *testing.T) {
+	shaStrs := []string{
+		"abcdefghij",
+		"abc",
+		"",
+	}
+	for i, shaStr := range shaStrs {
+		sha, err := NewSha(shaStr)
+		if err == nil {
+			t.Errorf("expected error for sha %s (#%d), got nothing", shaStr, i)
+			continue
+		}
+		if sha != nil {
+			t.Errorf("expected returned SHA struct to be nil, got %+v instead", *sha)
+		}
+	}
+}
+
+func TestNewSha(t *testing.T) {
+	shaStrs := []string{
+		"71a09fbed590558ff822536584fc77248f070384",
+		"39d8ef3ea964c98f884a67aecef56b4c8abfc700",
+		"1b48115b57304d04c8c2e72d62e0a9d1bcd0d48f",
+	}
+	for i, shaStr := range shaStrs {
+		sha, err := NewSha(shaStr)
+		if err != nil {
+			t.Errorf("expected no error for sha %s (#%d), got %s", shaStr, i, err)
+			continue
+		}
+		if sha.Full != shaStr {
+			t.Errorf("expected full sha string to be %s, got %s", shaStr, sha.Full)
+		}
+		if sha.Short != shaStr[0:8] {
+			t.Errorf("expected short sha to be first 8 characters of %s, got %s", shaStr, sha.Short)
+		}
+	}
+}

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -1,0 +1,28 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/deis/builder/pkg/gitreceive/git"
+)
+
+type SlugBuilderInfo struct {
+	PushKey string
+	PushURL string
+	TarKey  string
+	TarURL  string
+}
+
+func NewSlugBuilderInfo(s3Client *s3.S3, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
+	tarKey := fmt.Sprintf("home/%s/tar", slugName)
+	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
+	pushKey := fmt.Sprintf("home/%s/push", fmt.Sprintf("%s:git-%s", appName, gitSha.Short))
+
+	return &SlugBuilderInfo{
+		PushKey: pushKey,
+		PushURL: fmt.Sprintf("%s/%s", s3Client.Endpoint, pushKey),
+		TarKey:  tarKey,
+		TarURL:  fmt.Sprintf("%s/git/%s", s3Client.Endpoint, tarKey),
+	}
+}

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/deis/builder/pkg/gitreceive/git"
 )
 
+// SlugBuilderInfo contains all of the object storage related information needed to pass to a slug builder
 type SlugBuilderInfo struct {
 	PushKey string
 	PushURL string
@@ -14,15 +14,16 @@ type SlugBuilderInfo struct {
 	TarURL  string
 }
 
-func NewSlugBuilderInfo(s3Client *s3.S3, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
+// NewSlugBuilderInfo creates and populates a new SlugBuilderInfo based on the given data
+func NewSlugBuilderInfo(s3Endpoint, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
 	tarKey := fmt.Sprintf("home/%s/tar", slugName)
 	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
 	pushKey := fmt.Sprintf("home/%s/push", fmt.Sprintf("%s:git-%s", appName, gitSha.Short))
 
 	return &SlugBuilderInfo{
 		PushKey: pushKey,
-		PushURL: fmt.Sprintf("%s/%s", s3Client.Endpoint, pushKey),
+		PushURL: fmt.Sprintf("%s/%s", s3Endpoint, pushKey),
 		TarKey:  tarKey,
-		TarURL:  fmt.Sprintf("%s/git/%s", s3Client.Endpoint, tarKey),
+		TarURL:  fmt.Sprintf("%s/git/%s", s3Endpoint, tarKey),
 	}
 }

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -18,7 +18,7 @@ type SlugBuilderInfo struct {
 func NewSlugBuilderInfo(s3Endpoint, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
 	tarKey := fmt.Sprintf("home/%s/tar", slugName)
 	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
-	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Full)
+	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Full())
 
 	return &SlugBuilderInfo{
 		pushKey: pushKey,

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -18,11 +18,11 @@ type SlugBuilderInfo struct {
 func NewSlugBuilderInfo(s3Endpoint, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
 	tarKey := fmt.Sprintf("home/%s/tar", slugName)
 	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
-	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Short)
+	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Full)
 
 	return &SlugBuilderInfo{
 		PushKey: pushKey,
-		PushURL: fmt.Sprintf("%s/%s", s3Endpoint, pushKey),
+		PushURL: fmt.Sprintf("%s/git/%s", s3Endpoint, pushKey),
 		TarKey:  tarKey,
 		TarURL:  fmt.Sprintf("%s/git/%s", s3Endpoint, tarKey),
 	}

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -8,10 +8,10 @@ import (
 
 // SlugBuilderInfo contains all of the object storage related information needed to pass to a slug builder
 type SlugBuilderInfo struct {
-	PushKey string
-	PushURL string
-	TarKey  string
-	TarURL  string
+	pushKey string
+	pushURL string
+	tarKey  string
+	tarURL  string
 }
 
 // NewSlugBuilderInfo creates and populates a new SlugBuilderInfo based on the given data
@@ -21,9 +21,14 @@ func NewSlugBuilderInfo(s3Endpoint, appName, slugName string, gitSha *git.SHA) *
 	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Full)
 
 	return &SlugBuilderInfo{
-		PushKey: pushKey,
-		PushURL: fmt.Sprintf("%s/git/%s", s3Endpoint, pushKey),
-		TarKey:  tarKey,
-		TarURL:  fmt.Sprintf("%s/git/%s", s3Endpoint, tarKey),
+		pushKey: pushKey,
+		pushURL: fmt.Sprintf("%s/git/%s", s3Endpoint, pushKey),
+		tarKey:  tarKey,
+		tarURL:  fmt.Sprintf("%s/git/%s", s3Endpoint, tarKey),
 	}
 }
+
+func (s SlugBuilderInfo) PushKey() string { return s.pushKey }
+func (s SlugBuilderInfo) PushURL() string { return s.pushURL }
+func (s SlugBuilderInfo) TarKey() string  { return s.tarKey }
+func (s SlugBuilderInfo) TarURL() string  { return s.tarURL }

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -18,7 +18,7 @@ type SlugBuilderInfo struct {
 func NewSlugBuilderInfo(s3Endpoint, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
 	tarKey := fmt.Sprintf("home/%s/tar", slugName)
 	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
-	pushKey := fmt.Sprintf("home/%s/push", fmt.Sprintf("%s:git-%s", appName, gitSha.Short))
+	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Short)
 
 	return &SlugBuilderInfo{
 		PushKey: pushKey,

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/deis/builder/pkg/gitreceive/git"
@@ -20,10 +19,13 @@ func TestS3Endpoint(t *testing.T) {
 		t.Fatalf("error building git sha (%s)", err)
 	}
 	sbi := NewSlugBuilderInfo(s3Endpoint, appName, slugName, sha)
-	if !strings.HasPrefix(sbi.PushURL, s3Endpoint) {
-		t.Errorf("push URL %s didn't have expected s3 endpoint prefix %s", sbi.PushURL, s3Endpoint)
+
+	expectedPushURL := s3Endpoint + "/git/" + sbi.PushKey
+	if sbi.PushURL != expectedPushURL {
+		t.Errorf("push URL %s didn't match expected %s", sbi.PushURL, expectedPushURL)
 	}
-	if !strings.HasPrefix(sbi.TarURL, s3Endpoint) {
-		t.Errorf("tar URL %s didn't have expected s3 endpoint prefix %s", sbi.TarURL, s3Endpoint)
+	expectedTarURL := s3Endpoint + "/git/" + sbi.TarKey
+	if sbi.TarURL != expectedTarURL {
+		t.Errorf("tar URL %s didn't match expected %s", sbi.TarURL, expectedTarURL)
 	}
 }

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deis/builder/pkg/gitreceive/git"
+)
+
+const (
+	rawSha     = "c3b4e4ba8b7267226ff02ad07a3a2cca9c9237de"
+	s3Endpoint = "http://10.1.2.3:9090"
+	appName    = "myapp"
+	slugName   = "myslug"
+)
+
+func TestS3Endpoint(t *testing.T) {
+	sha, err := git.NewSha(rawSha)
+	if err != nil {
+		t.Fatalf("error building git sha (%s)", err)
+	}
+	sbi := NewSlugBuilderInfo(s3Endpoint, appName, slugName, sha)
+	if !strings.HasPrefix(sbi.PushURL, s3Endpoint) {
+		t.Errorf("push URL %s didn't have expected s3 endpoint prefix %s", sbi.PushURL, s3Endpoint)
+	}
+	if !strings.HasPrefix(sbi.TarURL, s3Endpoint) {
+		t.Errorf("tar URL %s didn't have expected s3 endpoint prefix %s", sbi.TarURL, s3Endpoint)
+	}
+}

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -20,12 +20,12 @@ func TestS3Endpoint(t *testing.T) {
 	}
 	sbi := NewSlugBuilderInfo(s3Endpoint, appName, slugName, sha)
 
-	expectedPushURL := s3Endpoint + "/git/" + sbi.PushKey
-	if sbi.PushURL != expectedPushURL {
-		t.Errorf("push URL %s didn't match expected %s", sbi.PushURL, expectedPushURL)
+	expectedPushURL := s3Endpoint + "/git/" + sbi.PushKey()
+	if sbi.PushURL() != expectedPushURL {
+		t.Errorf("push URL %s didn't match expected %s", sbi.PushURL(), expectedPushURL)
 	}
-	expectedTarURL := s3Endpoint + "/git/" + sbi.TarKey
-	if sbi.TarURL != expectedTarURL {
-		t.Errorf("tar URL %s didn't match expected %s", sbi.TarURL, expectedTarURL)
+	expectedTarURL := s3Endpoint + "/git/" + sbi.TarKey()
+	if sbi.TarURL() != expectedTarURL {
+		t.Errorf("tar URL %s didn't match expected %s", sbi.TarURL(), expectedTarURL)
 	}
 }

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -29,3 +29,27 @@ func TestS3Endpoint(t *testing.T) {
 		t.Errorf("tar URL %s didn't match expected %s", sbi.TarURL(), expectedTarURL)
 	}
 }
+
+func TestPushKey(t *testing.T) {
+	sha, err := git.NewSha(rawSha)
+	if err != nil {
+		t.Fatalf("error building git sha (%s)", err)
+	}
+	sbi := NewSlugBuilderInfo(s3Endpoint, appName, slugName, sha)
+	expectedPushKey := "home/" + appName + ":git-" + sha.Full() + "/push"
+	if sbi.PushKey() != expectedPushKey {
+		t.Errorf("push key %s didn't match expected %s", sbi.PushKey(), expectedPushKey)
+	}
+}
+
+func TestTarKey(t *testing.T) {
+	sha, err := git.NewSha(rawSha)
+	if err != nil {
+		t.Fatalf("error building git sha (%s)", err)
+	}
+	sbi := NewSlugBuilderInfo(s3Endpoint, appName, slugName, sha)
+	expectedTarKey := "home/" + slugName + "/tar"
+	if sbi.TarKey() != expectedTarKey {
+		t.Errorf("tar key %s didn't match expected %s", sbi.TarKey(), expectedTarKey)
+	}
+}


### PR DESCRIPTION
and representing the git sha in a struct to do so

Fixes #130 
Makes progress on #132 