### PR TITLE
fix(*): add readiness & liveness probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ RC := manifests/deis-${SHORT_NAME}-rc.yaml
 SVC := manifests/deis-${SHORT_NAME}-service.yaml
 IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
 
-TEST_PACKAGES := $(shell ${DEV_ENV_CMD} glide nv)
-
 all:
 	@echo "Use a Makefile to control top-level building of the project."
 
@@ -46,7 +44,7 @@ build:
 	@$(call check-static-binary,$(BINARY_DEST_DIR)/boot)
 
 test:
-	${DEV_ENV_CMD} go test ${TEST_PACKAGES}
+	${DEV_ENV_CMD} sh -c 'go test $$(glide nv)'
 
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs

--- a/boot.go
+++ b/boot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/deis/builder/pkg"
 	"github.com/deis/builder/pkg/conf"
 	"github.com/deis/builder/pkg/gitreceive"
+	"github.com/deis/builder/pkg/gitreceive/storage"
 	"github.com/deis/builder/pkg/sshd"
 	pkglog "github.com/deis/pkg/log"
 )
@@ -42,6 +43,13 @@ func main() {
 					pkglog.Err("getting config for %s [%s]", serverConfAppName, err)
 					os.Exit(1)
 				}
+				s3Client, err := storage.GetClient
+				if err != nil {
+					pkglog.Err("getting s3 client [%s]", err)
+					os.Exit(1)
+				}
+				pkglog.Info("starting health check server on port %d", cnf.HealthSrvPort)
+				go healthsrv.Start(cnf.HealtHSrvPort, s3Client)
 				pkglog.Info("starting SSH server on %s:%d", cnf.SSHHostIP, cnf.SSHHostPort)
 				os.Exit(pkg.Run(cnf.SSHHostIP, cnf.SSHHostPort, "boot"))
 			},

--- a/boot.go
+++ b/boot.go
@@ -12,7 +12,11 @@ import (
 	"github.com/deis/builder/pkg/gitreceive/storage"
 	"github.com/deis/builder/pkg/healthsrv"
 	"github.com/deis/builder/pkg/sshd"
+<<<<<<< 032d8fd56928af3492a8449e226d36d5324b8d2c
 	pkglog "github.com/deis/pkg/log"
+=======
+	kcl "k8s.io/kubernetes/pkg/client/unversioned"
+>>>>>>> fix(boot.go,pkg/healthsrv): add kubernetes API checks in the healthz endpoint
 )
 
 const (
@@ -49,10 +53,15 @@ func main() {
 					pkglog.Err("getting s3 client [%s]", err)
 					os.Exit(1)
 				}
+				kubeClient, err := kcl.NewInCluster()
+				if err != nil {
+					pkglog.Err("getting kubernetes client [%s]", err)
+					os.Exit(1)
+				}
 				pkglog.Info("starting health check server on port %d", cnf.HealthSrvPort)
 				healthSrvCh := make(chan error)
 				go func() {
-					if err := healthsrv.Start(cnf.HealthSrvPort, s3Client); err != nil {
+					if err := healthsrv.Start(cnf.HealthSrvPort, kubeClient.Namespaces(), s3Client); err != nil {
 						healthSrvCh <- err
 					}
 				}()

--- a/boot.go
+++ b/boot.go
@@ -30,8 +30,8 @@ func main() {
 	if os.Getenv("DEBUG") == "true" {
 		pkglog.DefaultLogger.SetDebug(true)
 		cookoolog.Level = cookoolog.LogDebug
+		log.Printf("Running in debug mode")
 	}
-	pkglog.Debug("Running in debug mode")
 
 	app := cli.NewApp()
 

--- a/boot.go
+++ b/boot.go
@@ -12,11 +12,8 @@ import (
 	"github.com/deis/builder/pkg/gitreceive/storage"
 	"github.com/deis/builder/pkg/healthsrv"
 	"github.com/deis/builder/pkg/sshd"
-<<<<<<< 032d8fd56928af3492a8449e226d36d5324b8d2c
 	pkglog "github.com/deis/pkg/log"
-=======
 	kcl "k8s.io/kubernetes/pkg/client/unversioned"
->>>>>>> fix(boot.go,pkg/healthsrv): add kubernetes API checks in the healthz endpoint
 )
 
 const (
@@ -48,9 +45,6 @@ func main() {
 					pkglog.Err("getting config for %s [%s]", serverConfAppName, err)
 					os.Exit(1)
 				}
-
-				serverCircuit := sshd.NewCircuit()
-
 				s3Client, err := storage.GetClient(cnf.HealthSrvTestStorageRegion)
 				if err != nil {
 					pkglog.Err("getting s3 client [%s]", err)
@@ -64,7 +58,7 @@ func main() {
 				pkglog.Info("starting health check server on port %d", cnf.HealthSrvPort)
 				healthSrvCh := make(chan error)
 				go func() {
-					if err := healthsrv.Start(cnf.HealthSrvPort, kubeClient.Namespaces(), s3Client, serverCircuit); err != nil {
+					if err := healthsrv.Start(cnf.HealthSrvPort, kubeClient.Namespaces(), s3Client); err != nil {
 						healthSrvCh <- err
 					}
 				}()
@@ -72,7 +66,7 @@ func main() {
 				pkglog.Info("starting SSH server on %s:%d", cnf.SSHHostIP, cnf.SSHHostPort)
 				sshCh := make(chan int)
 				go func() {
-					sshCh <- pkg.RunBuilder(cnf.SSHHostIP, cnf.SSHHostPort, serverCircuit)
+					sshCh <- pkg.Run(cnf.SSHHostIP, cnf.SSHHostPort, "boot")
 				}()
 
 				select {

--- a/boot.go
+++ b/boot.go
@@ -48,6 +48,9 @@ func main() {
 					pkglog.Err("getting config for %s [%s]", serverConfAppName, err)
 					os.Exit(1)
 				}
+
+				serverCircuit := sshd.NewCircuit()
+
 				s3Client, err := storage.GetClient(cnf.HealthSrvTestStorageRegion)
 				if err != nil {
 					pkglog.Err("getting s3 client [%s]", err)
@@ -61,7 +64,7 @@ func main() {
 				pkglog.Info("starting health check server on port %d", cnf.HealthSrvPort)
 				healthSrvCh := make(chan error)
 				go func() {
-					if err := healthsrv.Start(cnf.HealthSrvPort, kubeClient.Namespaces(), s3Client); err != nil {
+					if err := healthsrv.Start(cnf.HealthSrvPort, kubeClient.Namespaces(), s3Client, serverCircuit); err != nil {
 						healthSrvCh <- err
 					}
 				}()
@@ -69,7 +72,7 @@ func main() {
 				pkglog.Info("starting SSH server on %s:%d", cnf.SSHHostIP, cnf.SSHHostPort)
 				sshCh := make(chan int)
 				go func() {
-					sshCh <- pkg.Run(cnf.SSHHostIP, cnf.SSHHostPort, "boot")
+					sshCh <- pkg.RunBuilder(cnf.SSHHostIP, cnf.SSHHostPort, serverCircuit)
 				}()
 
 				select {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-updated: 2016-02-10T02:53:37.929806212Z
+hash: b7693d48b0561bf438eb2751e26cc053cfe1c46aad0ca1d97dbf95c5b4665af1
+updated: 2016-02-10T22:34:55.109010629Z
 imports:
 - name: bitbucket.org/bertimus9/systemstat
   version: 1468fd0db20598383c9393cccaa547de6ad99e5e
@@ -25,7 +25,7 @@ imports:
   version: ""
   repo: https://code.google.com/p/google-api-go-client
 - name: code.google.com/p/goprotobuf
-  version: d20896fc31fb0e955e57970d61eb6eea054ff048
+  version: 001690d39bd620847bb265d93a7c5e1bd3737308
   repo: https://github.com/golang/protobuf
 - name: code.google.com/p/gosqlite
   version: ""
@@ -108,6 +108,7 @@ imports:
   version: 25325b46b67d1c3eb7d58bad37d34d89a31cf9ec
 - name: github.com/cheggaaa/pb
   version: e67c2c3b91b15e81659790a8644e0d3b4a40271d
+  repo: https://github.com/cheggaaa/pb
 - name: github.com/ClusterHQ/flocker-go
   version: 3f33ece70f6571f0ec45bfae2f243ab11fab6c52
 - name: github.com/codegangsta/cli
@@ -132,6 +133,7 @@ imports:
   - unit
 - name: github.com/coreos/gexpect
   version: 0b5620b695de57d5fcea082b9a062157ac60ed73
+  repo: https://github.com/coreos/gexpect
 - name: github.com/coreos/go-etcd
   version: 4cceaf7283b76f27c4a732b20730dcdb61053bf5
   subpackages:
@@ -179,7 +181,7 @@ imports:
 - name: github.com/deckarep/golang-set
   version: ef32fa3046d9f249d399f98ebaf9be944430fd1d
 - name: github.com/deis/pkg
-  version: c85c2ef5e9e5ea570df66131f8906e409408a145
+  version: b8679a4d7fe2fe0393c66c620eff7df86c9f7982
   subpackages:
   - time
   - log
@@ -192,7 +194,7 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: 5ca80149b9d3f8b863af0e2bb6742e608603bd99
 - name: github.com/docker/distribution
-  version: db34a8ba9cdd1cb78fb08791025198e65b55046a
+  version: 77534e734063a203981df7024fe8ca9228b86930
   repo: https://github.com/docker/distribution
 - name: github.com/docker/docker
   version: 2b27fe17a1b3fb8472fde96d768fa70996adf201
@@ -217,7 +219,7 @@ imports:
 - name: github.com/docker/libkv
   version: c2aac5dbbaa5c872211edea7c0f32b3bd67e7410
 - name: github.com/docker/libnetwork
-  version: b3690009eaa84275e2024a5b567baa2d26db5dd1
+  version: 48ebfd635268ae33c6275007cdace21d9af5786d
   repo: https://github.com/docker/libnetwork
 - name: github.com/docker/libtrust
   version: fa567046d9b14f6aa788882a950d69651d230b21
@@ -259,6 +261,7 @@ imports:
   version: 193d1ecb466bf97aae8b454a5cfc192941c64809
 - name: github.com/godbus/dbus
   version: 939230d2086a4f1870e04c52e0a376c25bae0ec4
+  repo: https://github.com/godbus/dbus
 - name: github.com/gogo/protobuf
   version: 64f27bf06efee53589314a6e5a4af34cdd85adf6
   subpackages:
@@ -308,6 +311,7 @@ imports:
   - compute/metadata
 - name: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
+  repo: https://github.com/gorilla/context
 - name: github.com/gorilla/handlers
   version: 60c7bfde3e33c201519a200a4507a158cc03a17b
 - name: github.com/gorilla/mux
@@ -345,7 +349,7 @@ imports:
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   repo: https://github.com/hashicorp/golang-lru
 - name: github.com/hashicorp/hcl
-  version: 8cc810768200e949a2a92972845244f6a818f68d
+  version: 1c284ec98f4b398443cbabb0d9197f7f4cc0077c
   repo: https://github.com/hashicorp/hcl
 - name: github.com/hashicorp/logutils
   version: 0dc08b1671f34c4250ce212759ebd880f743d883
@@ -408,6 +412,7 @@ imports:
   version: 8fef92e41e22a70e700a96b29f066cda30ea24ef
 - name: github.com/kballard/go-shellquote
   version: d8ec1a69a250a17bb0e419c386eac1f3711dc142
+  repo: https://github.com/kballard/go-shellquote
 - name: github.com/kelseyhightower/envconfig
   version: 12c18e8343f6eb5fc3a9d5c8dc353e42e6bb40b9
 - name: github.com/kimor79/gollectd
@@ -417,6 +422,7 @@ imports:
   version: 088c856450c08c03eb32f7a6c221e6eefaa10e6f
 - name: github.com/kr/pty
   version: 05017fcccf23c823bfdea560dcc958a136e54fb7
+  repo: https://github.com/kr/pty
 - name: github.com/kr/text
   version: 6807e777504f54ad073ecef66747de158294b639
 - name: github.com/lsegal/gucumber
@@ -566,6 +572,7 @@ imports:
   version: 51ad44105773cafcbe91927f70ac68e1bf78f8b4
 - name: github.com/stretchr/objx
   version: d40df0cc104c06eae2dfe03d7dddb83802d52f9a
+  repo: https://github.com/stretchr/objx
 - name: github.com/stretchr/testify
   version: 9cc77fa25329013ce07362c7742952ff887361f2
   subpackages:
@@ -620,13 +627,16 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 2ea5e055772cf5daa0b1478d6e88c8d0c3d4cb79
+  version: 3cf1a407a4e2eedab950cb2caa897cb185354d0f
+  repo: https://golang.org/x/text
 - name: golang.org/x/tools
   version: 4f50f44d7a3206e9e28b984e023efce2a4a75369
 - name: google.golang.org/api
   version: 0c2979aeaa5b573e60d3ddffe5ce8dca8df309bd
+  repo: https://google.golang.org/api
 - name: google.golang.org/appengine
   version: 6a436539be38c296a8075a871cc536686b458371
+  repo: https://google.golang.org/appengine
 - name: google.golang.org/cloud
   version: f20d6dcccb44ed49de45ae3703312cb46e627db1
   subpackages:
@@ -647,6 +657,7 @@ imports:
   version: d466437aa4adc35830964cffc5b5f262c63ddcb4
 - name: gopkg.in/yaml.v1
   version: 9f9df34309c04878acc86042b16630b0f696e1de
+  repo: https://gopkg.in/yaml.v1
 - name: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - name: k8s.io/heapster

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,3 +35,5 @@ import:
   - service/s3
 - package: k8s.io/kubernetes
   version: ~1.1
+- package: github.com/arschles/assert
+  version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,6 +22,7 @@ import:
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - package: github.com/pborman/uuid
 - package: github.com/deis/pkg
+  version: b8679a4d7fe2fe0393c66c620eff7df86c9f7982
   subpackages:
   - time
   - log

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -21,8 +21,6 @@ spec:
           ports:
             - containerPort: 2223
               name: ssh
-            - containerPort: 3000
-              name: fetcher
             - containerPort: 8092
               name: healthsrv
           env:

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -23,7 +23,11 @@ spec:
               name: ssh
             - containerPort: 3000
               name: fetcher
+            - containerPort: 8092
+              name: healthServer
           env:
+            - name: "HEALTH_SERVER_PORT"
+              value: "8092"
             - name: "EXTERNAL_PORT"
               value: "2223"
             # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -39,6 +39,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: minio-user
               mountPath: /var/run/secrets/object/store

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -43,14 +43,14 @@ spec:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
+            initialDelaySeconds: 2
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
+            initialDelaySeconds: 2
+            timeoutSeconds: 1
           volumeMounts:
             - name: minio-user
               mountPath: /var/run/secrets/object/store

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: deis-builder
+  namespace: deis
   labels:
     heritage: deis
 spec:
@@ -15,21 +16,22 @@ spec:
     spec:
       containers:
         - name: deis-builder
-          imagePullPolicy: Always
           image: quay.io/deisci/builder:v2-beta
+          imagePullPolicy: Always
           ports:
             - containerPort: 2223
+              name: ssh
             - containerPort: 3000
+              name: fetcher
           env:
-            - name: BUILDER_FETCHER_PORT
-              value: "3000"
-            - name: BUILDER_SSH_HOST_IP
-              value: "0.0.0.0"
-            - name: BUILDER_SSH_HOST_PORT
-              value: "2223"
             - name: "EXTERNAL_PORT"
               value: "2223"
-            - name: POD_NAMESPACE
+            # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
+            - name: "DOCKERIMAGE"
+              value: "1"
+            - name: "DEBUG"
+              value: "true"
+            - name: "POD_NAMESPACE"
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -40,10 +42,6 @@ spec:
             - name: builder-key-auth
               mountPath: /var/run/secrets/api/auth
               readOnly: true
-            # not currently running minio with SSL support. see https://github.com/deis/minio/pull/22 for more detail
-            # - name: minio-ssl
-            #   mountPath: /var/run/secrets/object/ssl
-            #   readOnly: true
       volumes:
         - name: minio-user
           secret:
@@ -51,7 +49,3 @@ spec:
         - name: builder-key-auth
           secret:
             secretName: builder-key-auth
-        # not currently running minio with SSL support. see https://github.com/deis/minio/pull/22 for more detail
-        # - name: minio-ssl
-        #   secret:
-        #     secretName: minio-ssl

--- a/manifests/deis-builder-rc.yaml
+++ b/manifests/deis-builder-rc.yaml
@@ -24,7 +24,7 @@ spec:
             - containerPort: 3000
               name: fetcher
             - containerPort: 8092
-              name: healthServer
+              name: healthsrv
           env:
             - name: "HEALTH_SERVER_PORT"
               value: "8092"

--- a/manifests/deis-builder-service.yaml
+++ b/manifests/deis-builder-service.yaml
@@ -2,17 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: deis-builder
+  namespace: deis
   labels:
     heritage: deis
-    release: 2.0.0
 spec:
   ports:
-    - port: 2222
+    - name: ssh
+      port: 2222
       targetPort: 2223
-      name: ssh
-      protocol: TCP
-    - port: 3000
-      name: fetcher
-      protocol: TCP
   selector:
     app: deis-builder

--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -5,13 +5,12 @@ package pkg
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/Masterminds/cookoo"
 	clog "github.com/Masterminds/cookoo/log"
 	"github.com/deis/builder/pkg/sshd"
-
-	"log"
-	"os"
 )
 
 // Return codes that will be sent to the shell.
@@ -28,7 +27,7 @@ const (
 // Git.
 //
 // Run returns on of the Status* status code constants.
-func Run(sshHostIP string, sshHostPort int, cmd string) int {
+func RunBuilder(sshHostIP string, sshHostPort int, sshServerCircuit *sshd.Circuit) int {
 	reg, router, ocxt := cookoo.Cookoo()
 	log.SetFlags(0) // Time is captured elsewhere.
 
@@ -59,7 +58,7 @@ func Run(sshHostIP string, sshHostPort int, cmd string) int {
 	// Start the SSH service.
 	// TODO: We could refactor Serve to be a command, and then run this as
 	// a route.
-	if err := sshd.Serve(reg, router, cxt); err != nil {
+	if err := sshd.Serve(reg, router, sshServerCircuit, cxt); err != nil {
 		clog.Errf(cxt, "SSH server failed: %s", err)
 		return StatusLocalError
 	}

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -9,3 +9,10 @@ type BucketLister interface {
 	// ListBuckets lists all the buckets in the object storage system
 	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
 }
+
+type emptyBucketLister struct{}
+
+func (e emptyBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
+	var buckets []*s3.Bucket
+	return &s3.ListBucketsOutput{Buckets: buckets}, nil
+}

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -16,3 +16,11 @@ func (e emptyBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOut
 	var buckets []*s3.Bucket
 	return &s3.ListBucketsOutput{Buckets: buckets}, nil
 }
+
+type errBucketLister struct {
+	err error
+}
+
+func (e errBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
+	return nil, e.err
+}

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -1,0 +1,11 @@
+package healthsrv
+
+import (
+	s3 "github.com/aws/aws-sdk-go/service/s3"
+)
+
+// BucketLister is a *(github.com/aws/aws-sdk-go/service/s3).Client compatible interface that provides just the ListBuckets cross-section of functionality. It can also be implemented for unit tests
+type BucketLister interface {
+	// ListBuckets lists all the buckets in the object storage system
+	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
+}

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -24,3 +24,21 @@ type errBucketLister struct {
 func (e errBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
 	return nil, e.err
 }
+
+// listBuckets calls bl.ListBuckets(...) and sends the results back on the various given channels. This func is intended to be run in a goroutine and communicates via the channels it's passed.
+//
+// On success, it passes the bucket output on succCh, and on failure, it passes the error on errCh. At most one of {succCh, errCh} will be sent on. If stopCh is closed, no pending or future sends will occur.
+func listBuckets(bl BucketLister, succCh chan<- *s3.ListBucketsOutput, errCh chan<- error, stopCh <-chan struct{}) {
+	lbOut, err := bl.ListBuckets(&s3.ListBucketsInput{})
+	if err != nil {
+		select {
+		case errCh <- err:
+		case <-stopCh:
+		}
+		return
+	}
+	select {
+	case succCh <- lbOut:
+	case <-stopCh:
+	}
+}

--- a/pkg/healthsrv/circuit_state.go
+++ b/pkg/healthsrv/circuit_state.go
@@ -1,0 +1,25 @@
+package healthsrv
+
+import (
+	"fmt"
+
+	"github.com/deis/builder/pkg/sshd"
+)
+
+// circuitState determines whether circ.State() == sshd.ClosedState, and sends the results back on the various given channels. This func is intended to be run in a goroutine and communicates via the channels it's passed.
+//
+// If the circuit is closed, it passes an empty struct back on succCh. On failure, it sends an error back on errCh. At most one of {succCh, errCh} will be sent on. If stopCh is closed, no pending or future sends will occur.
+func circuitState(circ *sshd.Circuit, succCh chan<- struct{}, errCh chan<- error, stopCh <-chan struct{}) {
+	// There's a race between the boolean eval and the HTTP error returned (the circuit could close between the two). This function should be polled to avoid that problem. If it's being used in a k8s probe, then you're fine because k8s will repeat the health probe and effectively re-evaluate the boolean
+	if circ.State() != sshd.ClosedState {
+		select {
+		case errCh <- fmt.Errorf("SSH Server is not yet started"):
+		case <-stopCh:
+		}
+		return
+	}
+	select {
+	case succCh <- struct{}{}:
+	case <-stopCh:
+	}
+}

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -29,9 +29,9 @@ type healthZResp struct {
 	S3Buckets  []healthZRespBucket `json:"s3_buckets"`
 }
 
-func healthZHandler(nsLister NamespaceLister, s3Client *s3.S3) http.Handler {
+func healthZHandler(nsLister NamespaceLister, bLister BucketLister) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lbOut, err := s3Client.ListBuckets(&s3.ListBucketsInput{})
+		lbOut, err := bLister.ListBuckets(&s3.ListBucketsInput{})
 		if err != nil {
 			str := fmt.Sprintf("Error listing buckets (%s)", err)
 			log.Err(str)

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -33,8 +33,7 @@ type healthZResp struct {
 
 func healthZHandler(nsLister NamespaceLister, bLister BucketLister, serverCircuit *sshd.Circuit) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// there's a race between the boolean eval and the HTTP error returned, but k8s will repeat the health probe request
-		// and effectively re-evaluate the boolean.
+		// There's a race between the boolean eval and the HTTP error returned (the server could start up between the two), but k8s will repeat the health probe request and effectively re-evaluate the boolean. The result is that the server may not start until the next probe in those cases
 		if serverCircuit.State() != sshd.ClosedState {
 			str := fmt.Sprintf("SSH Server is not yet started")
 			log.Err(str)

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	s3 "github.com/aws/aws-sdk-go/service/s3"
-	"github.com/deis/builder/pkg/gitreceive/log"
 	"github.com/deis/builder/pkg/sshd"
+	"github.com/deis/pkg/log"
 	"k8s.io/kubernetes/pkg/api"
 )
 

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -38,14 +38,14 @@ func healthZHandler(nsLister NamespaceLister, bLister BucketLister, serverCircui
 		if serverCircuit.State() != sshd.ClosedState {
 			str := fmt.Sprintf("SSH Server is not yet started")
 			log.Err(str)
-			http.Error(w, str, http.StatusAccepted)
+			http.Error(w, str, http.StatusServiceUnavailable)
 			return
 		}
 		lbOut, err := bLister.ListBuckets(&s3.ListBucketsInput{})
 		if err != nil {
 			str := fmt.Sprintf("Error listing buckets (%s)", err)
 			log.Err(str)
-			http.Error(w, str, http.StatusInternalServerError)
+			http.Error(w, str, http.StatusServiceUnavailable)
 			return
 		}
 		var rsp healthZResp
@@ -55,9 +55,9 @@ func healthZHandler(nsLister NamespaceLister, bLister BucketLister, serverCircui
 
 		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
 		if err != nil {
-			str := fmt.Sprintf("Error listing buckets (%s)", err)
+			str := fmt.Sprintf("Error listing namespaces (%s)", err)
 			log.Err(str)
-			http.Error(w, str, http.StatusInternalServerError)
+			http.Error(w, str, http.StatusServiceUnavailable)
 			return
 		}
 		for _, ns := range nsList.Items {

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -1,0 +1,49 @@
+package healthsrv
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	s3 "github.com/aws/aws-sdk-go/service/s3"
+)
+
+type healthZRespBucket struct {
+	Name         string    `json:"name"`
+	CreationDate time.Time `json:"creation_date"`
+}
+
+func convertBucket(b *s3.Bucket) healthZRespBucket {
+	return healthZRespBucket{
+		Name:         *b.Name,
+		CreationDate: *b.CreationDate,
+	}
+}
+
+type healthZResp struct {
+	Buckets []healthZRespBucket `json:"buckets"`
+}
+
+func healthZHandler(s3Client *s3.S3) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lbOut, err := s3Client.ListBuckets(s3.ListBucketsInput{})
+		if err != nil {
+			str := fmt.Sprintf("Error listing buckets (%s)", err)
+			log.Printf(str)
+			http.Error(w, str, http.StatusInternalServerError)
+			return
+		}
+		var rsp healthZResp
+		for _, buck := range lbOut.Buckets {
+			rsp.Buckets = append(rsp.Buckets, convertBucket(buck))
+		}
+		if err := json.NewEncoder(w).Encode(rsp); err != nil {
+			str := fmt.Sprintf("Error encoding JSON (%s)", err)
+			http.Error(w, str, http.StatusInternalServerError)
+			return
+		}
+		// TODO: check k8s API
+		// TODO: check server is running
+	})
+}

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -27,7 +27,7 @@ type healthZResp struct {
 
 func healthZHandler(s3Client *s3.S3) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lbOut, err := s3Client.ListBuckets(s3.ListBucketsInput{})
+		lbOut, err := s3Client.ListBuckets(&s3.ListBucketsInput{})
 		if err != nil {
 			str := fmt.Sprintf("Error listing buckets (%s)", err)
 			log.Printf(str)

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	s3 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/deis/builder/pkg/gitreceive/log"
 )
 
 type healthZRespBucket struct {
@@ -30,7 +31,7 @@ func healthZHandler(s3Client *s3.S3) http.Handler {
 		lbOut, err := s3Client.ListBuckets(&s3.ListBucketsInput{})
 		if err != nil {
 			str := fmt.Sprintf("Error listing buckets (%s)", err)
-			log.Printf(str)
+			log.Info(str)
 			http.Error(w, str, http.StatusInternalServerError)
 			return
 		}

--- a/pkg/healthsrv/healthz_handler_test.go
+++ b/pkg/healthsrv/healthz_handler_test.go
@@ -1,0 +1,69 @@
+package healthsrv
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/builder/pkg/sshd"
+)
+
+var (
+	testErr = errors.New("test error")
+)
+
+func TestHealthZCircuitOpen(t *testing.T) {
+	nsLister := emptyNamespaceLister{}
+	bLister := emptyBucketLister{}
+	c := sshd.NewCircuit()
+
+	h := healthZHandler(nsLister, bLister, c)
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/healthz", bytes.NewBuffer(nil))
+	assert.NoErr(t, err)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
+	expectedBody := "SSH Server is not yet started"
+	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+}
+
+func TestHealthZBucketListErr(t *testing.T) {
+	nsLister := emptyNamespaceLister{}
+	bLister := errBucketLister{err: testErr}
+	c := sshd.NewCircuit()
+	c.Close()
+	h := healthZHandler(nsLister, bLister, c)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/healthz", bytes.NewBuffer(nil))
+	assert.NoErr(t, err)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
+	expectedBody := fmt.Sprintf("Error listing buckets (%s)", testErr)
+	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+}
+
+func TestHealthZNamespaceListErr(t *testing.T) {
+	nsLister := errNamespaceLister{err: testErr}
+	bLister := emptyBucketLister{}
+	c := sshd.NewCircuit()
+	c.Close()
+
+	h := healthZHandler(nsLister, bLister, c)
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/healthz", bytes.NewBuffer(nil))
+	assert.NoErr(t, err)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
+	expectedBody := fmt.Sprintf("Error listing namespaces (%s)", testErr)
+	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+}
+
+func TestHealthZSuccess(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/pkg/healthsrv/healthz_handler_test.go
+++ b/pkg/healthsrv/healthz_handler_test.go
@@ -2,12 +2,9 @@ package healthsrv
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -29,8 +26,7 @@ func TestHealthZCircuitOpen(t *testing.T) {
 	assert.NoErr(t, err)
 	h.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
-	expectedBody := "SSH Server is not yet started"
-	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+	assert.Equal(t, w.Body.Len(), 0, "response body length")
 }
 
 func TestHealthZBucketListErr(t *testing.T) {
@@ -45,8 +41,7 @@ func TestHealthZBucketListErr(t *testing.T) {
 	assert.NoErr(t, err)
 	h.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
-	expectedBody := fmt.Sprintf("Error listing buckets (%s)", testErr)
-	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+	assert.Equal(t, w.Body.Len(), 0, "response body length")
 }
 
 func TestHealthZNamespaceListErr(t *testing.T) {
@@ -61,8 +56,7 @@ func TestHealthZNamespaceListErr(t *testing.T) {
 	assert.NoErr(t, err)
 	h.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusServiceUnavailable, "response code")
-	expectedBody := fmt.Sprintf("Error listing namespaces (%s)", testErr)
-	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expectedBody, "response body")
+	assert.Equal(t, w.Body.Len(), 0, "response body length")
 }
 
 func TestHealthZSuccess(t *testing.T) {
@@ -77,8 +71,5 @@ func TestHealthZSuccess(t *testing.T) {
 	assert.NoErr(t, err)
 	h.ServeHTTP(w, r)
 	assert.Equal(t, w.Code, http.StatusOK, "response code")
-	expectedResp := healthZResp{Namespaces: nil, S3Buckets: nil, SSHServerStarted: true}
-	var expectedRespBytes bytes.Buffer
-	assert.NoErr(t, json.NewEncoder(&expectedRespBytes).Encode(expectedResp))
-	assert.Equal(t, string(w.Body.Bytes()), string(expectedRespBytes.Bytes()), "response body")
+	assert.Equal(t, w.Body.Len(), 0, "response body length")
 }

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -14,6 +14,14 @@ type NamespaceLister interface {
 
 type emptyNamespaceLister struct{}
 
-func (n noNamespacesLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
+func (n emptyNamespaceLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
 	return &api.NamespaceList{}, nil
+}
+
+type errNamespaceLister struct {
+	err error
+}
+
+func (e errNamespaceLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
+	return nil, e.err
 }

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -25,3 +25,22 @@ type errNamespaceLister struct {
 func (e errNamespaceLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
 	return nil, e.err
 }
+
+// listNamespaces calls nl.List(...) and sends the results back on the various given channels. This func is intended to be run in a goroutine and communicates via the channels it's passed.
+//
+// On success, it passes the namespace list on succCh, and on failure, it passes the error on errCh. At most one of {succCh, errCh} will be sent on. If stopCh is closed, no pending or future sends will occur.
+func listNamespaces(nl NamespaceLister, succCh chan<- *api.NamespaceList, errCh chan<- error, stopCh <-chan struct{}) {
+	nsList, err := nl.List(labels.Everything(), fields.Everything())
+	if err != nil {
+		select {
+		case errCh <- err:
+		case <-stopCh:
+		}
+		return
+	}
+	select {
+	case succCh <- nsList:
+	case <-stopCh:
+		return
+	}
+}

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -1,0 +1,11 @@
+package healthsrv
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+type NamespaceLister interface {
+	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
+}

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -11,3 +11,9 @@ type NamespaceLister interface {
 	// List lists all namespaces that are selected by the given label and field selectors
 	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
 }
+
+type emptyNamespaceLister struct{}
+
+func (n noNamespacesLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
+	return &api.NamespaceList{}, nil
+}

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
+// NamespaceLister is an (*k8s.io/kubernetes/pkg/client/unversioned).Client compatible interface that provides just the ListBuckets cross-section of functionality. It can also be implemented for unit tests.
 type NamespaceLister interface {
+	// List lists all namespaces that are selected by the given label and field selectors
 	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
 }

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -13,10 +13,10 @@ const (
 )
 
 // Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
-func Start(host string, port int, s3Client *s3.S3) error {
+func Start(port int, s3Client *s3.S3) error {
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", healthZHandler(s3Client))
 
-	hostStr := fmt.Sprintf("%s:%d", host, port)
+	hostStr := fmt.Sprintf("%d", port)
 	return http.ListenAndServe(hostStr, mux)
 }

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -3,8 +3,6 @@ package healthsrv
 import (
 	"fmt"
 	"net/http"
-
-	s3 "github.com/aws/aws-sdk-go/service/s3"
 )
 
 const (
@@ -13,9 +11,9 @@ const (
 )
 
 // Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
-func Start(port int, nsLister NamespaceLister, s3Client *s3.S3) error {
+func Start(port int, nsLister NamespaceLister, bLister BucketLister) error {
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", healthZHandler(nsLister, s3Client))
+	mux.Handle("/healthz", healthZHandler(nsLister, bLister))
 
 	hostStr := fmt.Sprintf(":%d", port)
 	return http.ListenAndServe(hostStr, mux)

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -1,0 +1,22 @@
+package healthsrv
+
+import (
+	"fmt"
+	"net/http"
+
+	s3 "github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	DefaultHost = "0.0.0.0"
+	DefaultPort = 8082
+)
+
+// Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
+func Start(host string, port int, s3Client *s3.S3) error {
+	mux := http.NewServeMux()
+	mux.Handle("/healthz", healthZHandler(s3Client))
+
+	hostStr := fmt.Sprintf("%s:%d", host, port)
+	return http.ListenAndServe(hostStr, mux)
+}

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -13,9 +13,9 @@ const (
 )
 
 // Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
-func Start(port int, s3Client *s3.S3) error {
+func Start(port int, nsLister NamespaceLister, s3Client *s3.S3) error {
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", healthZHandler(s3Client))
+	mux.Handle("/healthz", healthZHandler(nsLister, s3Client))
 
 	hostStr := fmt.Sprintf(":%d", port)
 	return http.ListenAndServe(hostStr, mux)

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -7,12 +7,7 @@ import (
 	"github.com/deis/builder/pkg/sshd"
 )
 
-const (
-	DefaultHost = "0.0.0.0"
-	DefaultPort = 8082
-)
-
-// Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
+// Start starts the healthcheck server on :$port and blocks. It only returns if the server fails, with the indicative error
 func Start(port int, nsLister NamespaceLister, bLister BucketLister, sshServerCircuit *sshd.Circuit) error {
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", healthZHandler(nsLister, bLister, sshServerCircuit))

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -17,6 +17,6 @@ func Start(port int, s3Client *s3.S3) error {
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", healthZHandler(s3Client))
 
-	hostStr := fmt.Sprintf("%d", port)
+	hostStr := fmt.Sprintf(":%d", port)
 	return http.ListenAndServe(hostStr, mux)
 }

--- a/pkg/healthsrv/server.go
+++ b/pkg/healthsrv/server.go
@@ -3,6 +3,8 @@ package healthsrv
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/deis/builder/pkg/sshd"
 )
 
 const (
@@ -11,9 +13,9 @@ const (
 )
 
 // Start starts the healthcheck server on $host:$port and blocks. It only returns if the server fails, with the indicative error
-func Start(port int, nsLister NamespaceLister, bLister BucketLister) error {
+func Start(port int, nsLister NamespaceLister, bLister BucketLister, sshServerCircuit *sshd.Circuit) error {
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", healthZHandler(nsLister, bLister))
+	mux.Handle("/healthz", healthZHandler(nsLister, bLister, sshServerCircuit))
 
 	hostStr := fmt.Sprintf(":%d", port)
 	return http.ListenAndServe(hostStr, mux)

--- a/pkg/sshd/circuit.go
+++ b/pkg/sshd/circuit.go
@@ -5,13 +5,17 @@ import (
 	"sync/atomic"
 )
 
+// CircuitState represents the state of a Circuit
 type CircuitState uint32
 
 const (
-	OpenState   CircuitState = 0
+	// OpenState indicates that the circuit is in the open state, and thus non-functional
+	OpenState CircuitState = 0
+	// ClosedState indicates that the circuit is in the closed state, and thus functional
 	ClosedState CircuitState = 1
 )
 
+// String is the fmt.Stringer interface implementation
 func (c CircuitState) String() string {
 	if c == OpenState {
 		return "OPEN"
@@ -31,11 +35,12 @@ func (s CircuitState) toUint32() uint32 {
 // - OpenState - non functional
 // - ClosedState - functional
 //
-//
+// The circuit is intended as a point-in-time indicator of functionality. It has no backoff mechanism, jitter or ramp-up/ramp-down functionality
 type Circuit struct {
 	bit uint32
 }
 
+// NewCircuit creates a new circuit, in the open (non-functional) state
 func NewCircuit() *Circuit {
 	return &Circuit{bit: OpenState.toUint32()}
 }

--- a/pkg/sshd/circuit.go
+++ b/pkg/sshd/circuit.go
@@ -1,0 +1,56 @@
+package sshd
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+type CircuitState uint32
+
+const (
+	OpenState   CircuitState = 0
+	ClosedState CircuitState = 1
+)
+
+func (c CircuitState) String() string {
+	if c == OpenState {
+		return "OPEN"
+	} else if c == ClosedState {
+		return "CLOSED"
+	} else {
+		return fmt.Sprintf("Unknown (%d)", c.toUint32())
+	}
+}
+
+func (s CircuitState) toUint32() uint32 {
+	return uint32(s)
+}
+
+// Circuit is a concurrency-safe data structure that can take one of two states at any point in time:
+//
+// - OpenState - non functional
+// - ClosedState - functional
+//
+//
+type Circuit struct {
+	bit uint32
+}
+
+func NewCircuit() *Circuit {
+	return &Circuit{bit: OpenState.toUint32()}
+}
+
+// State returns the current state of the circuit. Note that concurrent modifications may be happening, so the state may be different than what's returned
+func (c *Circuit) State() CircuitState {
+	return CircuitState(atomic.LoadUint32(&c.bit))
+}
+
+// Close closes the circuit if it wasn't already closed. Returns true if it had to be closed, false if it was already closed
+func (c *Circuit) Close() bool {
+	return atomic.CompareAndSwapUint32(&c.bit, OpenState.toUint32(), ClosedState.toUint32())
+}
+
+// Open opens the circuit if it wasn't already closed. Returns true if it had to be opened, false if it was already open
+func (c *Circuit) Open() bool {
+	return atomic.CompareAndSwapUint32(&c.bit, ClosedState.toUint32(), OpenState.toUint32())
+}

--- a/pkg/sshd/circuit_test.go
+++ b/pkg/sshd/circuit_test.go
@@ -1,0 +1,28 @@
+package sshd
+
+import (
+	"testing"
+)
+
+func TestOpenCloseSerial(t *testing.T) {
+	c := NewCircuit()
+	if c.State() != OpenState {
+		t.Fatalf("unexpected initial circuit state. want %s, got %s", OpenState, c.State())
+	}
+	if b := c.Close(); !b {
+		t.Fatalf("tried to close the circuit but it said it was already closed")
+	}
+	if c.State() != ClosedState {
+		t.Fatalf("unexpected circuit state. want %s, got %s", ClosedState, c.State())
+	}
+	if b := c.Open(); !b {
+		t.Fatalf("tried to open the circuit but it said it was already opened")
+	}
+	if c.State() != OpenState {
+		t.Fatalf("unexpected circuit state. want %s, got %s", OpenState, c.State())
+	}
+}
+
+func TestOpenCloseConcurrent(t *testing.T) {
+
+}

--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -2,6 +2,7 @@ package sshd
 
 // Config represents the required SSH server configuration
 type Config struct {
-	SSHHostIP   string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
-	SSHHostPort int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
+	SSHHostIP     string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
+	SSHHostPort   int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
+	HealthSrvPort int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
 }

--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -2,7 +2,8 @@ package sshd
 
 // Config represents the required SSH server configuration
 type Config struct {
-	SSHHostIP     string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
-	SSHHostPort   int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
-	HealthSrvPort int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
+	SSHHostIP                  string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
+	SSHHostPort                int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
+	HealthSrvPort              int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
+	HealthSrvTestStorageRegion string `envconfig:"HELATH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
 }

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -46,7 +46,7 @@ const (
 //
 // This puts the following variables into the context:
 // 	- ssh.Closer (chan interface{}): Send a message to this to shutdown the server.
-func Serve(reg *cookoo.Registry, router *cookoo.Router, c cookoo.Context) cookoo.Interrupt {
+func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, c cookoo.Context) cookoo.Interrupt {
 	hostkeys := c.Get(HostKeys, []ssh.Signer{}).([]ssh.Signer)
 	addr := c.Get(Address, "0.0.0.0:2223").(string)
 	cfg := c.Get(ServerConfig, &ssh.ServerConfig{}).(*ssh.ServerConfig)
@@ -70,6 +70,7 @@ func Serve(reg *cookoo.Registry, router *cookoo.Router, c cookoo.Context) cookoo
 	c.Put("sshd.Closer", closer)
 
 	log.Infof(c, "Listening on %s", addr)
+	serverCircuit.Close()
 	srv.listen(listener, cfg, closer)
 
 	return nil

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -9,7 +9,9 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-var testingServerAddr = "127.0.0.1:2244"
+const (
+	testingServerAddr = "127.0.0.1:2244"
+)
 
 // TestServer tests the SSH server.
 //

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -84,10 +84,6 @@ func sshTestingHostKey() (ssh.Signer, error) {
 	return ssh.ParsePrivateKey([]byte(testingHostKey))
 }
 
-func sshTestingClientKey() (ssh.Signer, error) {
-	return ssh.ParsePrivateKey([]byte(testingClientKey))
-}
-
 func runServer(config *ssh.ServerConfig, c *Circuit, t *testing.T) cookoo.Context {
 	reg, router, cxt := cookoo.Cookoo()
 	cxt.Put(ServerConfig, config)

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -29,10 +29,15 @@ func TestServer(t *testing.T) {
 	}
 	cfg.AddHostKey(key)
 
-	cxt := runServer(&cfg, t)
+	c := NewCircuit()
+	cxt := runServer(&cfg, c, t)
 
 	// Give server time to initialize.
 	time.Sleep(200 * time.Millisecond)
+
+	if c.State() != ClosedState {
+		t.Fatalf("circuit was not in closed state")
+	}
 
 	// Connect to the server and issue env var set. This should return true.
 	client, err := ssh.Dial("tcp", testingServerAddr, &ssh.ClientConfig{})
@@ -77,7 +82,11 @@ func sshTestingHostKey() (ssh.Signer, error) {
 	return ssh.ParsePrivateKey([]byte(testingHostKey))
 }
 
-func runServer(config *ssh.ServerConfig, t *testing.T) cookoo.Context {
+func sshTestingClientKey() (ssh.Signer, error) {
+	return ssh.ParsePrivateKey([]byte(testingClientKey))
+}
+
+func runServer(config *ssh.ServerConfig, c *Circuit, t *testing.T) cookoo.Context {
 	reg, router, cxt := cookoo.Cookoo()
 	cxt.Put(ServerConfig, config)
 	cxt.Put(Address, testingServerAddr)
@@ -99,7 +108,7 @@ func runServer(config *ssh.ServerConfig, t *testing.T) cookoo.Context {
 	})
 
 	go func() {
-		if err := Serve(reg, router, cxt); err != nil {
+		if err := Serve(reg, router, c, cxt); err != nil {
 			t.Fatalf("Failed serving with %s", err)
 		}
 	}()

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-# install git and configure gituser
+# specify the git user's home and name
 ENV GITHOME /home/git
 ENV GITUSER git
 # this is so the minio client (https://github.com/minio/mc) works properly


### PR DESCRIPTION
Fixes #92 
Fixes #89 
Ref deis/deis#4809
When this is done, merge deis/charts#93

# PR Overview

- Added a health check server with a single endpoint (`/healthz`), intended to be used by the `livenessProbe` and `readinessProbe`.
  - This endpoint checks the accessibility of the Kubernetes API & the object storage system, and checks that the SSH server is ready to serve
  - The health check server utilizes two `interface`s - for S3 interaction and Kubernetes API interaction - so that those two components can be mocked and the server can be more easily unit tested
  - The handler for the `/healthz` endpoint does all three checks concurrently, and only fails if one or more of them don't complete before a hard-coded timeout, or any of them fail before the timeout
- Added a `(github.com/deis/builder/pkg/sshd).Circuit` type, which acts as a simple, concurrency-safe on/off switch for communication across concurrency barriers. A `Circuit` is used to allow the SSH server to tell the health check server when it's ready to serve
- Modified `boot.go` to serve the SSH server and the health check server concurrently, but to kill the process with an error code if either fails
- Modified the manifests to closely resemble those in github.com/deis/charts (#89)
- Added liveness and readiness checks to the `deis-builder-rc.yaml` manifest
- Modified the `Makefile` to only look for non-vendored packages when `make test` is run, which makes all runs faster

# Still TODO

- [x] Check k8s server on probe request
- [x] Check that the server is actually running on probe request
- [x] Tests for `healthZHandler`
- [x] `TestOpenCloseConcurrent`
- [x] `make test` output: `pkg/sshd/server_test.go:106: not enough arguments in call to Serve`