### PR TITLE
fix(pkg/gitreceive/build.go): send the entire slug URL to the controller

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -217,6 +217,8 @@ func build(conf *Config, s3Client *s3.S3, kubeClient *client.Client, builderKey,
 	}
 	if !usingDockerfile {
 		buildHook.Dockerfile = ""
+		// need this to tell the controller what URL to give the slug runner
+		buildHook.Image = slugBuilderInfo.PushURL() + "/slug.tgz"
 	} else {
 		buildHook.Dockerfile = "true"
 	}


### PR DESCRIPTION
The controller now expects builder to send the *entire* slug URL to it. It then forwards that URL to the slugrunner that it launches.

This makes builder compatible with the changes in https://github.com/deis/workflow/pull/346