### PR TITLE
ref(rootfs/Dockerfile): consolidate RUN command

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,8 +3,17 @@ FROM alpine:3.3
 # install git and configure gituser
 ENV GITHOME /home/git
 ENV GITUSER git
+# this is so the minio client (https://github.com/minio/mc) works properly
+ENV DOCKERIMAGE=1
+ENV DEIS_BUILDER_SERVER_FETCHER_PORT=3000
+ENV DEIS_BUILDER_SERVER_SSH_HOST_IP=0.0.0.0
+ENV DEIS_BUILDER_SERVER_SSH_HOST_PORT=2223
 
-# install common packages
+EXPOSE 2223
+EXPOSE 3000
+
+# install common packages, install & configure the SSH server, and set up directories, users & perms.
+# NOTE: $GITUSER is added to docker group to use docker without sudo and to slug group in order to share resources with the slug user
 RUN apk add --update-cache \
   bash \
   sudo \
@@ -13,28 +22,18 @@ RUN apk add --update-cache \
   coreutils \
   tar \
   xz \
-  && rm -rf /var/cache/apk/*
-
-# install & configure the SSH server, then set up directories, users and perms.
-# NOTE: $GITUSER is added to docker group to use docker without sudo and to slug group in order to share resources with the slug user
-RUN mkdir -p /var/run/sshd && rm -rf /etc/ssh/ssh_host* \
-    && mkdir /apps \
-    && adduser -D -h $GITHOME $GITUSER \
-    && mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh \
-    && chown -R $GITUSER:$GITUSER $GITHOME \
-    && addgroup -g 2000 slug && adduser -D -u 2000 -G slug slug \
-    && addgroup $GITUSER slug \
-    && passwd -u git
+  && rm -rf /var/cache/apk/* \
+  && mkdir -p /var/run/sshd && rm -rf /etc/ssh/ssh_host* \
+  && mkdir /apps \
+  && adduser -D -h $GITHOME $GITUSER \
+  && mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh \
+  && chown -R $GITUSER:$GITUSER $GITHOME \
+  && addgroup -g 2000 slug && adduser -D -u 2000 -G slug slug \
+  && addgroup $GITUSER slug \
+  && passwd -u git
 
 COPY . /
 
-# this is so the minio client (https://github.com/minio/mc) works properly
-ENV DOCKERIMAGE=1
 ENV DEIS_RELEASE 2.0.0-dev
-ENV DEIS_BUILDER_SERVER_FETCHER_PORT=3000
-ENV DEIS_BUILDER_SERVER_SSH_HOST_IP=0.0.0.0
-ENV DEIS_BUILDER_SERVER_SSH_HOST_PORT=2223
 
 ENTRYPOINT ["boot", "server"]
-EXPOSE 2223
-EXPOSE 3000


### PR DESCRIPTION
There’s no reason I know of to separate some commands into another
layer. Also, move some ENVs and port expositions to the top, as they’re
almost never changed as well.

Depends on #173 before merge, since that will introduce Dockerfile tests into branch tests.