### PR TITLE
fix(boot.go,pkg/*): implement a deleted app cleaner

### DIFF
--- a/boot.go
+++ b/boot.go
@@ -72,7 +72,7 @@ func main() {
 				log.Printf("Starting deleted app cleaner")
 				cleanerErrCh := make(chan error)
 				go func() {
-					if err := cleaner.Run(gitHomeDir, kubeClient.Namespaces(), deleteLock, cnf.CleanerPollSleepDuration); err != nil {
+					if err := cleaner.Run(gitHomeDir, kubeClient.Namespaces(), deleteLock, cnf.CleanerPollSleepDuration()); err != nil {
 						cleanerErrCh <- err
 					}
 				}()

--- a/boot.go
+++ b/boot.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"runtime"
-	"time"
 
 	cookoolog "github.com/Masterminds/cookoo/log"
 	"github.com/codegangsta/cli"
@@ -23,7 +22,6 @@ const (
 	serverConfAppName     = "deis-builder-server"
 	gitReceiveConfAppName = "deis-builder-git-receive"
 	gitHomeDir            = "/home/git"
-	cleanerPollDuration   = 1 * time.Second // TODO: make this configurable
 )
 
 func init() {
@@ -72,7 +70,7 @@ func main() {
 				log.Printf("Starting deleted app cleaner")
 				cleanerErrCh := make(chan error)
 				go func() {
-					if err := cleaner.Run(gitHomeDir, kubeClient.Namespaces(), cleanerPollDuration); err != nil {
+					if err := cleaner.Run(gitHomeDir, kubeClient.Namespaces(), cnf.CleanerPollSleepDuration); err != nil {
 						cleanerErrCh <- err
 					}
 				}()

--- a/boot.go
+++ b/boot.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"time"
 
 	cookoolog "github.com/Masterminds/cookoo/log"
 	"github.com/codegangsta/cli"
@@ -20,6 +21,8 @@ import (
 const (
 	serverConfAppName     = "deis-builder-server"
 	gitReceiveConfAppName = "deis-builder-git-receive"
+	gitHomeDir            = "/home/git"
+	cleanerPollDuration   = 1 * time.Second // TODO: make this configurable
 )
 
 func init() {
@@ -69,7 +72,7 @@ func main() {
 				log.Printf("Starting SSH server on %s:%d", cnf.SSHHostIP, cnf.SSHHostPort)
 				sshCh := make(chan int)
 				go func() {
-					sshCh <- pkg.RunBuilder(cnf.SSHHostIP, cnf.SSHHostPort, circ)
+					sshCh <- pkg.RunBuilder(cnf.SSHHostIP, cnf.SSHHostPort, gitHomeDir, circ)
 				}()
 
 				select {

--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -27,7 +27,7 @@ const (
 // Git.
 //
 // Run returns on of the Status* status code constants.
-func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerCircuit *sshd.Circuit) int {
+func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerCircuit *sshd.Circuit, pushLock sshd.RepositoryLock, deleteLock sshd.RepositoryLock) int {
 	reg, router, ocxt := cookoo.Cookoo()
 	log.SetFlags(0) // Time is captured elsewhere.
 
@@ -58,7 +58,7 @@ func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerC
 	// Start the SSH service.
 	// TODO: We could refactor Serve to be a command, and then run this as
 	// a route.
-	if err := sshd.Serve(reg, router, sshServerCircuit, gitHomeDir, cxt); err != nil {
+	if err := sshd.Serve(reg, router, sshServerCircuit, gitHomeDir, pushLock, deleteLock, cxt); err != nil {
 		clog.Errf(cxt, "SSH server failed: %s", err)
 		return StatusLocalError
 	}

--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/cookoo"
 	clog "github.com/Masterminds/cookoo/log"
+	"github.com/deis/builder/pkg/cleaner"
 	"github.com/deis/builder/pkg/sshd"
 )
 
@@ -27,7 +28,7 @@ const (
 // Git.
 //
 // Run returns on of the Status* status code constants.
-func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerCircuit *sshd.Circuit, pushLock sshd.RepositoryLock, deleteLock sshd.RepositoryLock) int {
+func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerCircuit *sshd.Circuit, pushLock sshd.RepositoryLock, cleanerRef cleaner.Ref) int {
 	reg, router, ocxt := cookoo.Cookoo()
 	log.SetFlags(0) // Time is captured elsewhere.
 
@@ -58,7 +59,7 @@ func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerC
 	// Start the SSH service.
 	// TODO: We could refactor Serve to be a command, and then run this as
 	// a route.
-	if err := sshd.Serve(reg, router, sshServerCircuit, gitHomeDir, pushLock, deleteLock, cxt); err != nil {
+	if err := sshd.Serve(reg, router, sshServerCircuit, gitHomeDir, pushLock, cleanerRef, cxt); err != nil {
 		clog.Errf(cxt, "SSH server failed: %s", err)
 		return StatusLocalError
 	}

--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -27,7 +27,7 @@ const (
 // Git.
 //
 // Run returns on of the Status* status code constants.
-func RunBuilder(sshHostIP string, sshHostPort int, sshServerCircuit *sshd.Circuit) int {
+func RunBuilder(sshHostIP string, sshHostPort int, gitHomeDir string, sshServerCircuit *sshd.Circuit) int {
 	reg, router, ocxt := cookoo.Cookoo()
 	log.SetFlags(0) // Time is captured elsewhere.
 
@@ -58,7 +58,7 @@ func RunBuilder(sshHostIP string, sshHostPort int, sshServerCircuit *sshd.Circui
 	// Start the SSH service.
 	// TODO: We could refactor Serve to be a command, and then run this as
 	// a route.
-	if err := sshd.Serve(reg, router, sshServerCircuit, cxt); err != nil {
+	if err := sshd.Serve(reg, router, sshServerCircuit, gitHomeDir, cxt); err != nil {
 		clog.Errf(cxt, "SSH server failed: %s", err)
 		return StatusLocalError
 	}

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -64,6 +64,8 @@ func stripSuffixes(strs []string, suffix string) []string {
 		idx := strings.LastIndex(str, suffix)
 		if idx >= 0 {
 			ret[i] = str[:idx]
+		} else {
+			ret[i] = str
 		}
 	}
 	return ret

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -1,0 +1,94 @@
+// Package cleaner is a background process that compares the kubernetes namespace list with the folders in the local git home directory, deleting what's not in the namespace list
+package cleaner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/deis/builder/pkg/k8s"
+	"github.com/deis/pkg/log"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func localDirs(gitHome string) ([]string, error) {
+	var ret []string
+	err := filepath.Walk(gitHome, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return filepath.SkipDir
+		}
+		ret = append(ret, filepath.Join(gitHome, path))
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// getDisjunction gets the items that are in namespaceList and not in dirs or vice versa
+func getDisjunction(namespaceList []api.Namespace, dirs []string) []string {
+	var ret []string
+	namespacesSet := make(map[string]struct{})
+	dirsSet := make(map[string]struct{})
+
+	// create sets of the namespaces and dirs
+	for _, ns := range namespaceList {
+		lowerName := strings.ToLower(ns.Name)
+		namespacesSet[lowerName] = struct{}{}
+	}
+
+	for _, dir := range dirs {
+		lowerName := strings.ToLower(dir)
+		dirsSet[lowerName] = struct{}{}
+	}
+
+	// get dirs not in the namespaces set
+	for _, dir := range dirs {
+		lowerName := strings.ToLower(dir)
+		if _, ok := namespacesSet[lowerName]; !ok {
+			ret = append(ret, lowerName)
+		}
+	}
+
+	// get namespaces not in the dirs set
+	for _, ns := range namespaceList {
+		lowerName := strings.ToLower(ns.Name)
+		if _, ok := dirsSet[lowerName]; !ok {
+			ret = append(ret, lowerName)
+		}
+	}
+
+	return ret
+}
+
+func Run(gitHome string, nsLister k8s.NamespaceLister, pollInterval time.Duration) error {
+	for {
+		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
+		if err != nil {
+			log.Debug("Cleaner error listing namespaces (%s)", err)
+			continue
+		}
+
+		gitDirs, err := localDirs(gitHome)
+		if err != nil {
+			log.Debug("Cleaner error listing local git directories (%s)", err)
+		}
+
+		disjunctions := getDisjunction(nsList.Items, gitDirs)
+		for _, disj := range disjunctions {
+			if err := os.RemoveAll(disj); err != nil {
+				log.Debug("Cleaner error removing deleted app %s (%s)", disj, err)
+			}
+		}
+
+		time.Sleep(pollInterval)
+	}
+}

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -69,9 +69,9 @@ func getDisjunction(namespaceList []api.Namespace, dirs []string) []string {
 	return ret
 }
 
-// Run starts the deleted app cleaner. Every pollInterval, it compares the result of nsLister.List with the directories in the top level of gitHome on the local file system. On any error, it uses log.Debug to output a human readable description of what happened.
+// Run starts the deleted app cleaner. Every pollSleepDuration, it compares the result of nsLister.List with the directories in the top level of gitHome on the local file system. On any error, it uses log.Debug to output a human readable description of what happened.
 // TODO: locking mechanism on repositories. Nobody should be able to push to a repo while one is being deleted
-func Run(gitHome string, nsLister k8s.NamespaceLister, pollInterval time.Duration) error {
+func Run(gitHome string, nsLister k8s.NamespaceLister, pollSleepDuration time.Duration) error {
 	for {
 		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
 		if err != nil {
@@ -91,6 +91,6 @@ func Run(gitHome string, nsLister k8s.NamespaceLister, pollInterval time.Duratio
 			}
 		}
 
-		time.Sleep(pollInterval)
+		time.Sleep(pollSleepDuration)
 	}
 }

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -69,6 +69,8 @@ func getDisjunction(namespaceList []api.Namespace, dirs []string) []string {
 	return ret
 }
 
+// Run starts the deleted app cleaner. Every pollInterval, it compares the result of nsLister.List with the directories in the top level of gitHome on the local file system. On any error, it uses log.Debug to output a human readable description of what happened.
+// TODO: locking mechanism on repositories. Nobody should be able to push to a repo while one is being deleted
 func Run(gitHome string, nsLister k8s.NamespaceLister, pollInterval time.Duration) error {
 	for {
 		nsList, err := nsLister.List(labels.Everything(), fields.Everything())

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -61,13 +61,13 @@ func Run(gitHome string, nsLister k8s.NamespaceLister, repoLock sshd.RepositoryL
 	for {
 		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
 		if err != nil {
-			log.Debug("Cleaner error listing namespaces (%s)", err)
+			log.Err("Cleaner error listing namespaces (%s)", err)
 			continue
 		}
 
 		gitDirs, err := localDirs(gitHome)
 		if err != nil {
-			log.Debug("Cleaner error listing local git directories (%s)", err)
+			log.Err("Cleaner error listing local git directories (%s)", err)
 		}
 
 		dirsToDelete := getDiff(nsList.Items, gitDirs)
@@ -78,14 +78,14 @@ func Run(gitHome string, nsLister k8s.NamespaceLister, repoLock sshd.RepositoryL
 		}
 		for _, dirToDelete := range dirsToDelete {
 			if err := repoLock.Lock(dirToDelete, time.Duration(0)); err != nil {
-				log.Debug("Cleaner error locking repository %s for deletion (%s)", dirToDelete, err)
+				log.Err("Cleaner error locking repository %s for deletion (%s)", dirToDelete, err)
 				continue
 			}
 			if err := os.RemoveAll(dirToDelete); err != nil {
-				log.Debug("Cleaner error removing deleted app %s (%s)", dirToDelete, err)
+				log.Err("Cleaner error removing deleted app %s (%s)", dirToDelete, err)
 			}
 			if err := repoLock.Unlock(dirToDelete, time.Duration(0)); err != nil {
-				log.Debug("Cleaner error unlocking repository %s for deletion (%s)", dirToDelete, err)
+				log.Err("Cleaner error unlocking repository %s for deletion (%s)", dirToDelete, err)
 				continue
 			}
 		}

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -71,6 +71,11 @@ func Run(gitHome string, nsLister k8s.NamespaceLister, repoLock sshd.RepositoryL
 		}
 
 		dirsToDelete := getDiff(nsList.Items, gitDirs)
+		if len(dirsToDelete) > 0 {
+			log.Debug("Cleaner found the following git directories to delete: %s", dirsToDelete)
+		} else {
+			log.Debug("Cleaner found no git directories to delete")
+		}
 		for _, dirToDelete := range dirsToDelete {
 			if err := repoLock.Lock(dirToDelete, time.Duration(0)); err != nil {
 				log.Debug("Cleaner error locking repository %s for deletion (%s)", dirToDelete, err)

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -63,8 +63,9 @@ func TestLocalDirs(t *testing.T) {
 }
 
 func TestStripSuffixes(t *testing.T) {
-	strs := []string{"a.git", "b.git", "c.git"}
+	strs := []string{"a.git", "b.git", "c.git", "d"}
 	newStrs := stripSuffixes(strs, dotGitSuffix)
+	assert.Equal(t, len(newStrs), len(strs), "number of strings")
 	for _, str := range newStrs {
 		assert.False(t, strings.HasSuffix(str, dotGitSuffix), "string %s has suffix %s", str, dotGitSuffix)
 	}

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -10,14 +10,14 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func TestGetDisjunction(t *testing.T) {
+func TestGetDiff(t *testing.T) {
 	nsList := []api.Namespace{
 		api.Namespace{ObjectMeta: api.ObjectMeta{Name: "app1"}},
 		api.Namespace{ObjectMeta: api.ObjectMeta{Name: "app2"}},
 	}
 	dirList := []string{"app1", "app3"}
-	disj := getDisjunction(nsList, dirList)
-	assert.Equal(t, len(disj), 2, "number of items in the disjunction")
+	diff := getDiff(nsList, dirList)
+	assert.Equal(t, len(diff), 1, "number of items in the disjunction")
 }
 
 func TestLocalDirs(t *testing.T) {

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -1,0 +1,35 @@
+package cleaner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arschles/assert"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestGetDisjunction(t *testing.T) {
+	nsList := []api.Namespace{
+		api.Namespace{ObjectMeta: api.ObjectMeta{Name: "app1"}},
+		api.Namespace{ObjectMeta: api.ObjectMeta{Name: "app2"}},
+	}
+	dirList := []string{"app1", "app3"}
+	disj := getDisjunction(nsList, dirList)
+	assert.Equal(t, len(disj), 2, "number of items in the disjunction")
+}
+
+func TestLocalDirs(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoErr(t, err)
+	pkgDir, err := filepath.Abs(wd + "/..")
+	assert.NoErr(t, err)
+	lDirs, err := localDirs(pkgDir)
+	for _, dir := range lDirs {
+		rel, err := filepath.Rel(pkgDir, dir)
+		assert.NoErr(t, err)
+		spl := strings.Split(rel, "/")
+		assert.Equal(t, len(spl), 1, "directory depth")
+	}
+}

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -20,12 +20,20 @@ func TestGetDiff(t *testing.T) {
 	assert.Equal(t, len(diff), 1, "number of items in the disjunction")
 }
 
+func TestDirHasGitSuffix(t *testing.T) {
+	assert.True(t, dirHasGitSuffix("a.git"), "'a.git' reported no git suffix")
+	assert.False(t, dirHasGitSuffix("abc"), "'a' reported git suffix")
+}
+
 func TestLocalDirs(t *testing.T) {
 	wd, err := os.Getwd()
 	assert.NoErr(t, err)
 	pkgDir, err := filepath.Abs(wd + "/..")
 	assert.NoErr(t, err)
-	lDirs, err := localDirs(pkgDir)
+	lDirs, err := localDirs(pkgDir, func(dir string) bool {
+		// no directories with any dots in them
+		return len(strings.Split(dir, ".")) == 1
+	})
 	assert.NoErr(t, err)
 
 	expectedPackages := map[string]int{

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -26,10 +26,46 @@ func TestLocalDirs(t *testing.T) {
 	pkgDir, err := filepath.Abs(wd + "/..")
 	assert.NoErr(t, err)
 	lDirs, err := localDirs(pkgDir)
-	for _, dir := range lDirs {
-		rel, err := filepath.Rel(pkgDir, dir)
-		assert.NoErr(t, err)
-		spl := strings.Split(rel, "/")
-		assert.Equal(t, len(spl), 1, "directory depth")
+	assert.NoErr(t, err)
+
+	expectedPackages := map[string]int{
+		pkgDir + "/cleaner":    1,
+		pkgDir + "/conf":       1,
+		pkgDir + "/controller": 1,
+		pkgDir + "/env":        1,
+		pkgDir + "/git":        1,
+		pkgDir + "/gitreceive": 1,
+		pkgDir + "/healthsrv":  1,
+		pkgDir + "/k8s":        1,
+		pkgDir + "/sshd":       1,
+	}
+
+	actualPackages := map[string]int{}
+	for _, lDir := range lDirs {
+		actualPackages[lDir]++
+	}
+	assert.Equal(t, len(actualPackages), len(expectedPackages), "number of packages")
+	for actualPackageName, actualNum := range actualPackages {
+		if actualNum != 1 {
+			t.Errorf("found %d %s packages", actualNum, actualPackageName)
+			continue
+		}
+		expectedNum, ok := expectedPackages[actualPackageName]
+		if !ok {
+			t.Errorf("found unexpected package %s", actualPackageName)
+			continue
+		}
+		if actualNum != expectedNum {
+			t.Errorf("found %d %s packages, expected %d", actualNum, actualPackageName, expectedNum)
+			continue
+		}
+	}
+}
+
+func TestStripSuffixes(t *testing.T) {
+	strs := []string{"a.git", "b.git", "c.git"}
+	newStrs := stripSuffixes(strs, dotGitSuffix)
+	for _, str := range newStrs {
+		assert.False(t, strings.HasSuffix(str, dotGitSuffix), "string %s has suffix %s", str, dotGitSuffix)
 	}
 }

--- a/pkg/k8s/namespace.go
+++ b/pkg/k8s/namespace.go
@@ -1,0 +1,17 @@
+package k8s
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// NamespaceLister is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible interface which only has the List function. It's used in places that only need List to make them easier to test and more easily swappable with other implementations.
+//
+// Example usage:
+//
+//	var nsl NamespaceLister
+//	nsl = kubeClient.Namespaces()
+type NamespaceLister interface {
+	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
+}

--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -6,9 +6,13 @@ import (
 
 // Config represents the required SSH server configuration
 type Config struct {
-	SSHHostIP                  string        `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
-	SSHHostPort                int           `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
-	HealthSrvPort              int           `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
-	HealthSrvTestStorageRegion string        `envconfig:"HEALTH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
-	CleanerPollSleepDuration   time.Duration `envconfig:"CLEANER_POLL_SLEEP_DURATION" default:"1s"`
+	SSHHostIP                   string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
+	SSHHostPort                 int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
+	HealthSrvPort               int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
+	HealthSrvTestStorageRegion  string `envconfig:"HEALTH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
+	CleanerPollSleepDurationSec int    `envconfig:"CLEANER_POLL_SLEEP_DURATION_SEC" default:"1"`
+}
+
+func (c Config) CleanerPollSleepDuration() time.Duration {
+	return time.Duration(c.CleanerPollSleepDurationSec) * time.Second
 }

--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -1,9 +1,14 @@
 package sshd
 
+import (
+	"time"
+)
+
 // Config represents the required SSH server configuration
 type Config struct {
-	SSHHostIP                  string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
-	SSHHostPort                int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
-	HealthSrvPort              int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
-	HealthSrvTestStorageRegion string `envconfig:"HELATH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
+	SSHHostIP                  string        `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
+	SSHHostPort                int           `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
+	HealthSrvPort              int           `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
+	HealthSrvTestStorageRegion string        `envconfig:"HEALTH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
+	CleanerPollSleepDuration   time.Duration `envconfig:"CLEANER_POLL_SLEEP_DURATION" default:"1"`
 }

--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -10,5 +10,5 @@ type Config struct {
 	SSHHostPort                int           `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
 	HealthSrvPort              int           `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
 	HealthSrvTestStorageRegion string        `envconfig:"HEALTH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
-	CleanerPollSleepDuration   time.Duration `envconfig:"CLEANER_POLL_SLEEP_DURATION" default:"1"`
+	CleanerPollSleepDuration   time.Duration `envconfig:"CLEANER_POLL_SLEEP_DURATION" default:"1s"`
 }

--- a/pkg/sshd/lock.go
+++ b/pkg/sshd/lock.go
@@ -20,12 +20,27 @@ type RepositoryLock interface {
 	Unlock(repoName string, timeout time.Duration) error
 }
 
+type mutexLock struct {
+	mut *sync.Mutex
+}
+
+func (m *mutexLock) Lock(string, time.Duration) error {
+	m.mut.Lock()
+	return nil
+}
+
+func (m *mutexLock) Unlock(string, time.Duration) error {
+	m.mut.Unlock()
+	return nil
+}
+
 // NewInMemoryRepositoryLock returns a new instance of a RepositoryLock
 func NewInMemoryRepositoryLock() RepositoryLock {
-	return &inMemoryRepoLock{
-		mutex:   &sync.RWMutex{},
-		dataMap: make(map[string]bool),
-	}
+	return &mutexLock{mut: new(sync.Mutex)}
+	// return &inMemoryRepoLock{
+	// 	mutex:   &sync.RWMutex{},
+	// 	dataMap: make(map[string]bool),
+	// }
 }
 
 type inMemoryRepoLock struct {

--- a/pkg/sshd/lock.go
+++ b/pkg/sshd/lock.go
@@ -20,27 +20,12 @@ type RepositoryLock interface {
 	Unlock(repoName string, timeout time.Duration) error
 }
 
-type mutexLock struct {
-	mut *sync.Mutex
-}
-
-func (m *mutexLock) Lock(string, time.Duration) error {
-	m.mut.Lock()
-	return nil
-}
-
-func (m *mutexLock) Unlock(string, time.Duration) error {
-	m.mut.Unlock()
-	return nil
-}
-
 // NewInMemoryRepositoryLock returns a new instance of a RepositoryLock
 func NewInMemoryRepositoryLock() RepositoryLock {
-	return &mutexLock{mut: new(sync.Mutex)}
-	// return &inMemoryRepoLock{
-	// 	mutex:   &sync.RWMutex{},
-	// 	dataMap: make(map[string]bool),
-	// }
+	return &inMemoryRepoLock{
+		mutex:   &sync.RWMutex{},
+		dataMap: make(map[string]bool),
+	}
 }
 
 type inMemoryRepoLock struct {

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -12,8 +12,6 @@ import (
 	"io"
 	"net"
 	"strings"
-	"sync"
-	"text/template"
 	"time"
 
 	"github.com/Masterminds/cookoo"
@@ -31,10 +29,8 @@ const (
 	ServerConfig string = "ssh.ServerConfig"
 
 	multiplePush string = "Another git push is ongoing"
-)
 
-var (
-	buildingRepos = NewInMemoryRepositoryLock()
+	inProgressDelete string = "This app was deleted and is being cleaned up. Please re-create it with 'deis create your_app'"
 )
 
 // Serve starts a native SSH server.
@@ -54,7 +50,7 @@ var (
 //
 // This puts the following variables into the context:
 // 	- ssh.Closer (chan interface{}): Send a message to this to shutdown the server.
-func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, gitHomeDir string, c cookoo.Context) cookoo.Interrupt {
+func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, gitHomeDir string, concurrentPushLock RepositoryLock, concurrentDeleteLock RepositoryLock, c cookoo.Context) cookoo.Interrupt {
 	hostkeys := c.Get(HostKeys, []ssh.Signer{}).([]ssh.Signer)
 	addr := c.Get(Address, "0.0.0.0:2223").(string)
 	cfg := c.Get(ServerConfig, &ssh.ServerConfig{}).(*ssh.ServerConfig)
@@ -70,8 +66,10 @@ func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, 
 	}
 
 	srv := &server{
-		c:       c,
-		gitHome: gitHomeDir,
+		c:          c,
+		gitHome:    gitHomeDir,
+		pushLock:   concurrentPushLock,
+		deleteLock: concurrentDeleteLock,
 	}
 
 	closer := make(chan interface{}, 1)
@@ -88,8 +86,8 @@ func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, 
 type server struct {
 	c          cookoo.Context
 	gitHome    string
-	hookTpl    *template.Template
-	createLock sync.Mutex
+	pushLock   RepositoryLock
+	deleteLock RepositoryLock
 }
 
 // listen handles accepting and managing connections. However, since closer
@@ -225,7 +223,17 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 				}
 
 				repoName := parts[1]
-				if err := buildingRepos.Lock(repoName, time.Duration(0)); err != nil {
+				if err := s.deleteLock.Lock(repoName, time.Duration(0)); err != nil {
+					log.Errf(s.c, inProgressDelete)
+					// The error must be in git format
+					if err := gitPktLine(channel, fmt.Sprintf("ERR %v\n", inProgressDelete)); err != nil {
+						log.Errf(s.c, "Failed to write to channel: %s", err)
+					}
+					sendExitStatus(1, channel)
+					req.Reply(false, nil)
+					return nil
+				}
+				if err := s.pushLock.Lock(repoName, time.Duration(0)); err != nil {
 					log.Errf(s.c, multiplePush)
 					// The error must be in git format
 					if err := gitPktLine(channel, fmt.Sprintf("ERR %v\n", multiplePush)); err != nil {
@@ -244,7 +252,16 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 				cxt.Put("repository", parts[1])
 				sshGitReceive := cxt.Get("route.sshd.sshGitReceive", "sshGitReceive").(string)
 				err := router.HandleRequest(sshGitReceive, cxt, true)
-				buildingRepos.Unlock(repoName, time.Duration(0))
+				if err := s.pushLock.Unlock(repoName, time.Duration(0)); err != nil {
+					log.Errf(s.c, "unable to unlock repository lock for %s (%s)", repoName, err)
+					// TODO: this is an important error case that needs to be covered
+					// Probably the best solution is to change the lock into a lease so that even on unlock failures, RepositoryLock will eventually yield
+				}
+				if err := s.deleteLock.Unlock(repoName, time.Duration(0)); err != nil {
+					log.Errf(s.c, "unable to unlock delete lock for %s (%s)", repoName, err)
+					// TODO: this is an important error case that needs to be covered
+					// Probably the best solution is to change the lock into a lease so that even on unlock failures, RepositoryLock will eventually yield
+				}
 				var xs uint32
 				if err != nil {
 					log.Errf(s.c, "Failed git receive: %v", err)

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -232,7 +232,6 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 				}
 
 				repoName := parts[1]
-				fmt.Printf("Server locking %s for delete\n", repoName)
 				s.cleanerRef.Lock()
 				if err := s.pushLock.Lock(repoName, time.Duration(0)); err != nil {
 					log.Errf(s.c, multiplePush)
@@ -260,7 +259,6 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 					// Probably the best solution is to change the lock into a lease so that even on unlock failures, RepositoryLock will eventually yield
 				}
 				s.cleanerRef.Unlock()
-				fmt.Printf("Server unlocked %s for delete\n", repoName)
 				var xs uint32
 				if err != nil {
 					log.Errf(s.c, "Failed git receive: %v", err)

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -54,7 +54,7 @@ var (
 //
 // This puts the following variables into the context:
 // 	- ssh.Closer (chan interface{}): Send a message to this to shutdown the server.
-func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, c cookoo.Context) cookoo.Interrupt {
+func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, gitHomeDir string, c cookoo.Context) cookoo.Interrupt {
 	hostkeys := c.Get(HostKeys, []ssh.Signer{}).([]ssh.Signer)
 	addr := c.Get(Address, "0.0.0.0:2223").(string)
 	cfg := c.Get(ServerConfig, &ssh.ServerConfig{}).(*ssh.ServerConfig)
@@ -71,7 +71,7 @@ func Serve(reg *cookoo.Registry, router *cookoo.Router, serverCircuit *Circuit, 
 
 	srv := &server{
 		c:       c,
-		gitHome: "/home/git",
+		gitHome: gitHomeDir,
 	}
 
 	closer := make(chan interface{}, 1)

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/deis/builder/pkg/controller"
 
 	"github.com/Masterminds/cookoo"
+	"github.com/deis/builder/pkg/cleaner"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -269,8 +270,9 @@ func runServer(config *ssh.ServerConfig, c *Circuit, pushLock RepositoryLock, de
 		},
 	})
 
+	cleanerRef := cleaner.NewRef()
 	go func() {
-		if err := Serve(reg, router, c, gitHome, pushLock, deleteLock, cxt); err != nil {
+		if err := Serve(reg, router, c, gitHome, pushLock, cleanerRef, cxt); err != nil {
 			t.Fatalf("Failed serving with %s", err)
 		}
 	}()

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -203,10 +203,10 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create client session: %s", err)
 	}
-	if out, err := sess.Output("git-upload-pack /" + repoName + ".git"); err == nil {
-		t.Error("Expected concurrent delete error, got nothing")
-	} else if string(out) == "OK" {
-		t.Errorf("Expected error output, got %s", string(out))
+	if out, err := sess.Output("git-upload-pack /" + repoName + ".git"); err != nil {
+		t.Errorf("expected no error, got %s", err)
+	} else if string(out) != "OK" {
+		t.Errorf("Expected 'OK' output, got %s", string(out))
 	}
 	sess.Close()
 }

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -14,6 +14,8 @@ import (
 const (
 	testingServerAddr  = "127.0.0.1:2244"
 	testingServerAddr2 = "127.0.0.1:2245"
+	testingServerAddr3 = "127.0.0.1:2246"
+	gitHome            = "/git"
 )
 
 // TestServer tests the SSH server.
@@ -35,7 +37,9 @@ func TestReceive(t *testing.T) {
 	cfg.AddHostKey(key)
 
 	c := NewCircuit()
-	cxt := runServer(&cfg, c, testingServerAddr, t)
+	pushLock := NewInMemoryRepositoryLock()
+	deleteLock := NewInMemoryRepositoryLock()
+	cxt := runServer(&cfg, c, pushLock, deleteLock, testingServerAddr, t)
 
 	// Give server time to initialize.
 	time.Sleep(200 * time.Millisecond)
@@ -94,7 +98,9 @@ func TestPush(t *testing.T) {
 	cfg.AddHostKey(key)
 
 	c := NewCircuit()
-	runServer(&cfg, c, testingServerAddr2, t)
+	pushLock := NewInMemoryRepositoryLock()
+	deleteLock := NewInMemoryRepositoryLock()
+	runServer(&cfg, c, pushLock, deleteLock, testingServerAddr2, t)
 
 	// Give server time to initialize.
 	time.Sleep(200 * time.Millisecond)
@@ -146,12 +152,70 @@ func TestPush(t *testing.T) {
 	sess.Close()
 }
 
+func TestDelete(t *testing.T) {
+	key, err := sshTestingHostKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	cfg.AddHostKey(key)
+
+	c := NewCircuit()
+	pushLock := NewInMemoryRepositoryLock()
+	deleteLock := NewInMemoryRepositoryLock()
+	runServer(&cfg, c, pushLock, deleteLock, testingServerAddr3, t)
+
+	// Give server time to initialize.
+	time.Sleep(200 * time.Millisecond)
+
+	if c.State() != ClosedState {
+		t.Fatalf("circuit was not in closed state")
+	}
+
+	// Connect to the server and issue env var set. This should return true.
+	client, err := ssh.Dial("tcp", testingServerAddr2, &ssh.ClientConfig{})
+	if err != nil {
+		t.Fatalf("Failed to connect client to local server: %s", err)
+	}
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("Failed to create client session: %s", err)
+	}
+
+	// check for invalid length of arguments
+	if out, err := sess.Output("git-upload-pack"); err == nil {
+		t.Errorf("Expected an error but '%s' was received", out)
+	} else if string(out) != "" {
+		t.Errorf("Expected , got '%s'", out)
+	}
+	sess.Close()
+
+	repoName := "demo"
+	if err := deleteLock.Lock(repoName, time.Duration(0)); err != nil {
+		t.Fatalf("Error locking the delete lock (%s)", err)
+	}
+
+	sess, err = client.NewSession()
+	if err != nil {
+		t.Fatalf("Failed to create client session: %s", err)
+	}
+	if out, err := sess.Output("git-upload-pack /" + repoName + ".git"); err == nil {
+		t.Error("Expected concurrent delete error, got nothing")
+	} else if string(out) == "OK" {
+		t.Errorf("Expected error output, got %s", string(out))
+	}
+	sess.Close()
+}
+
 // sshTestingHostKey loads the testing key.
 func sshTestingHostKey() (ssh.Signer, error) {
 	return ssh.ParsePrivateKey([]byte(testingHostKey))
 }
 
-func runServer(config *ssh.ServerConfig, c *Circuit, testAddr string, t *testing.T) cookoo.Context {
+func runServer(config *ssh.ServerConfig, c *Circuit, pushLock RepositoryLock, deleteLock RepositoryLock, testAddr string, t *testing.T) cookoo.Context {
 	reg, router, cxt := cookoo.Cookoo()
 	cxt.Put(ServerConfig, config)
 	cxt.Put(Address, testAddr)
@@ -206,7 +270,7 @@ func runServer(config *ssh.ServerConfig, c *Circuit, testAddr string, t *testing
 	})
 
 	go func() {
-		if err := Serve(reg, router, c, cxt); err != nil {
+		if err := Serve(reg, router, c, gitHome, pushLock, deleteLock, cxt); err != nil {
 			t.Fatalf("Failed serving with %s", err)
 		}
 	}()


### PR DESCRIPTION
# Overview

This PR introduces a background goroutine that polls the Kubernetes API for the list of namespaces and compares those names with those in its local git folder. The cleaner then deletes all directories that exist locally but not in the namespace list.

# Testing Instructions

To test, follow these steps:

1. Create an app and `git push` to it from repository A
2. `deis apps:destroy -a your_app`
3. Wait at least the polling interval (the default is 1 second)
4. Re-create an app of the same name from repository B (so that the `deis` tool creates the same remote in repo B). Make sure repository B has a different set of refs from A
5. `git push` from repo B

The push should be successful and the app should run properly.

Still TODO:

- [x] Lock repositories in-memory while they're being deleted. The SSH server should reject pushes to repos that are currently being deleted. Depends on #170 for the `RepositoryLock` primitive in order to achieve this locking
- [x] Make the cleaner's poll duration configurable (it's currently hard-coded)

Notes:

- This PR also introduces global locks on `git push`es, effectively removing some of the functionality in #170, but still preventing concurrent git pushes. We may want to hold on this PR in order to get back to full feature parity with that introduced in #170
- Assuming the previous were fixed, this PR could still introduce an edge case that can impact performance negatively. See https://github.com/deis/builder/issues/192 for details and a proposed solution.
- There's a polling window for the cleaner. If a user deletes an app, re-creates it, and pushes a different repo within that window, they'll see errors. See https://github.com/deis/builder/issues/193 for details and a proposed solution.

Fixes #167 