### PR TITLE
feat(storage): change outside storage settings

### DIFF
--- a/pkg/gitreceive/storage/endpoint.go
+++ b/pkg/gitreceive/storage/endpoint.go
@@ -6,31 +6,28 @@ import (
 )
 
 const (
-	minioHostEnvVar          = "DEIS_MINIO_SERVICE_HOST"
-	minioPortEnvVar          = "DEIS_MINIO_SERVICE_PORT"
-	outsideStorageHostEnvVar = "DEIS_OUTSIDE_STORAGE_HOST"
-	outsideStoragePortEnvVar = "DEIS_OUTSIDE_STORAGE_PORT"
+	minioHostEnvVar        = "DEIS_MINIO_SERVICE_HOST"
+	minioPortEnvVar        = "DEIS_MINIO_SERVICE_PORT"
+	outsideStorageEndpoint = "DEIS_OUTSIDE_STORAGE"
 )
 
 var (
 	errNoStorageConfig = fmt.Errorf(
-		"no storage config variables found (%s:%s or %s:%s)",
+		"no storage config variables found (%s:%s or %s)",
 		minioHostEnvVar,
 		minioPortEnvVar,
-		outsideStorageHostEnvVar,
-		outsideStoragePortEnvVar,
+		outsideStorageEndpoint,
 	)
 )
 
 func getEndpoint() (string, error) {
 	mHost := os.Getenv(minioHostEnvVar)
 	mPort := os.Getenv(minioPortEnvVar)
-	oHost := os.Getenv(outsideStorageHostEnvVar)
-	oPort := os.Getenv(outsideStoragePortEnvVar)
-	if mHost != "" && mPort != "" {
+	S3EP := os.Getenv(outsideStorageEndpoint)
+	if S3EP != "" {
+		return S3EP, nil
+	} else if mHost != "" && mPort != "" {
 		return fmt.Sprintf("http://%s:%s", mHost, mPort), nil
-	} else if oHost != "" && oPort != "" {
-		return fmt.Sprintf("https://%s:%s", oHost, oPort), nil
 	} else {
 		return "", errNoStorageConfig
 	}


### PR DESCRIPTION
Directly set outside storage URL . example 
```
 - name: "DEIS_OUTSIDE_STORAGE"
   value: "https://storage.googleapis.com"
```
first preference to S3 endpoint then minio 