### PR TITLE
feat(storage): use single storage region variable

### DIFF
--- a/pkg/sshd/config.go
+++ b/pkg/sshd/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	SSHHostIP                   string `envconfig:"SSH_HOST_IP" default:"0.0.0.0" required:"true"`
 	SSHHostPort                 int    `envconfig:"SSH_HOST_PORT" default:"2223" required:"true"`
 	HealthSrvPort               int    `envconfig:"HEALTH_SERVER_PORT" default:"8092"`
-	HealthSrvTestStorageRegion  string `envconfig:"HEALTH_SERVER_TEST_STORAGE_REGION" default:"us-east-1"`
+	HealthSrvTestStorageRegion  string `envconfig:"STORAGE_REGION" default:"us-east-1"`
 	CleanerPollSleepDurationSec int    `envconfig:"CLEANER_POLL_SLEEP_DURATION_SEC" default:"1"`
 }
 


### PR DESCRIPTION
We have two storage region environment variables to check pod liveness and to upload content. To avaoid confusion use only one storage env 