### PR TITLE
feat(race): waitforpod errors out only for timeout

### DIFF
--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	PodNamespace                  string `envconfig:"POD_NAMESPACE" required:"true"`
 	StorageRegion                 string `envconfig:"STORAGE_REGION" default:"us-east-1"`
 	Debug                         bool   `envconfig:"DEBUG" default:"false"`
-	BuilderPodTickDurationMSec    int    `envconfig:"BUILDER_POD_TICK_DURATION" default:"100"`
+	BuilderPodTickDurationMSec    int    `envconfig:"BUILDER_POD_TICK_DURATION" default:"300"`
 	BuilderPodWaitDurationMSec    int    `envconfig:"BUILDER_POD_WAIT_DURATION" default:"300000"` // 5 minutes
 	ObjectStorageTickDurationMSec int    `envconfing:"OBJECT_STORAGE_TICK_DURATION" default:"500"`
 	ObjectStorageWaitDurationMSec int    `envconfig:"OBJECT_STORAGE_WAIT_DURATION" default:"300000"` // 5 minutes

--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -183,7 +183,7 @@ func waitForPodCondition(c *client.Client, ns, podName string, condition func(po
 		pod, err := c.Pods(ns).Get(podName)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
-				return true, err
+				return false, nil
 			}
 		}
 


### PR DESCRIPTION
This doesn't error out if POD is not present.
Only error condition is timeout 
