### PR TITLE
fix(pkg/sshd): demote handshake failure log to debug

### DIFF
--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -135,7 +135,7 @@ func (s *server) handleConn(conn net.Conn, conf *ssh.ServerConfig) {
 	_, chans, reqs, err := ssh.NewServerConn(conn, conf)
 	if err != nil {
 		// Handshake failure.
-		log.Errf(s.c, "Failed handshake: %s (%v)", err, conn)
+		log.Debugf(s.c, "Failed handshake: %s", err)
 		return
 	}
 


### PR DESCRIPTION
It's okay for connections to probe the server without initiating
a handshake, but it's still useful for developers to see when incoming
connections are not connecting.

see deis/deis#4935 for the backported fix