### PR TITLE
feat(race): change heritage label for every pod launch

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -96,8 +96,7 @@ func buildPod(debug, withAuth bool, name, namespace string, env map[string]inter
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"heritage": "deis",
-				"version":  "2.0.0-beta",
+				"heritage": name,
 			},
 		},
 	}


### PR DESCRIPTION
Having same labels for every slugbuilder launch makes GC to garbage collect.
This PR fixes terminating behavior for pod. Also we haven't pin pointed the root cause for this behavior.
Listening for event stream wont help in fixing this issue.