### PR TITLE
fix(config.go): increase builder pod wait duration

### DIFF
--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	StorageRegion                 string `envconfig:"STORAGE_REGION" default:"us-east-1"`
 	Debug                         bool   `envconfig:"DEBUG" default:"false"`
 	BuilderPodTickDurationMSec    int    `envconfig:"BUILDER_POD_TICK_DURATION" default:"100"`
-	BuilderPodWaitDurationMSec    int    `envconfig:"BUILDER_POD_WAIT_DURATION" default:"300000"` // 5 minutes
+	BuilderPodWaitDurationMSec    int    `envconfig:"BUILDER_POD_WAIT_DURATION" default:"900000"` // 15 minutes
 	ObjectStorageTickDurationMSec int    `envconfing:"OBJECT_STORAGE_TICK_DURATION" default:"500"`
 	ObjectStorageWaitDurationMSec int    `envconfig:"OBJECT_STORAGE_WAIT_DURATION" default:"300000"` // 5 minutes
 	Bucket                        string `envconfig:"BUCKET" default:"git"`


### PR DESCRIPTION
Set it to 15 minutes, which is the same as the Heroku default. See
https://devcenter.heroku.com/articles/slug-compiler

Fixes #205 