### PR TITLE
feat(server): add more tests for the SSH server

### DIFF
--- a/boot.go
+++ b/boot.go
@@ -72,7 +72,7 @@ func main() {
 				log.Printf("Starting deleted app cleaner")
 				cleanerErrCh := make(chan error)
 				go func() {
-					if err := cleanerRef.Run(gitHomeDir, kubeClient.Namespaces(), cleanerRef, cnf.CleanerPollSleepDuration()); err != nil {
+					if err := cleanerRef.Run(gitHomeDir, kubeClient.Namespaces(), cnf.CleanerPollSleepDuration()); err != nil {
 						cleanerErrCh <- err
 					}
 				}()

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -21,19 +21,11 @@ const (
 )
 
 type Ref struct {
-	mut *sync.RWMutex
+	mut *sync.Mutex
 }
 
 func NewRef() Ref {
-	return Ref{mut: new(sync.RWMutex)}
-}
-
-func (c Ref) RLock() {
-	c.mut.RLock()
-}
-
-func (c Ref) RUnlock() {
-	c.mut.RUnlock()
+	return Ref{mut: new(sync.Mutex)}
 }
 
 func (c Ref) Lock() {

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -103,7 +103,7 @@ func dirHasGitSuffix(dir string) bool {
 }
 
 // Run starts the deleted app cleaner. Every pollSleepDuration, it compares the result of nsLister.List with the directories in the top level of gitHome on the local file system. On any error, it uses log messages to output a human readable description of what happened.
-func (c Ref) Run(gitHome string, nsLister k8s.NamespaceLister, ref Ref, pollSleepDuration time.Duration) error {
+func (c Ref) Run(gitHome string, nsLister k8s.NamespaceLister, pollSleepDuration time.Duration) error {
 	for {
 		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
 		if err != nil {
@@ -128,11 +128,11 @@ func (c Ref) Run(gitHome string, nsLister k8s.NamespaceLister, ref Ref, pollSlee
 
 		for _, appToDelete := range appsToDelete {
 			dirToDelete := appToDelete + dotGitSuffix
-			ref.Lock()
+			c.Lock()
 			if err := os.RemoveAll(dirToDelete); err != nil {
 				log.Printf("Cleaner error removing deleted app %s (%s)", dirToDelete, err)
 			}
-			ref.Unlock()
+			c.Unlock()
 		}
 
 		time.Sleep(pollSleepDuration)

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -21,11 +21,19 @@ const (
 )
 
 type Ref struct {
-	mut *sync.Mutex
+	mut *sync.RWMutex
 }
 
 func NewRef() Ref {
-	return Ref{mut: new(sync.Mutex)}
+	return Ref{mut: new(sync.RWMutex)}
+}
+
+func (c Ref) RLock() {
+	c.mut.RLock()
+}
+
+func (c Ref) RUnlock() {
+	c.mut.RUnlock()
 }
 
 func (c Ref) Lock() {

--- a/pkg/sshd/common_test.go
+++ b/pkg/sshd/common_test.go
@@ -1,0 +1,26 @@
+package sshd
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	errWGTimedOut = errors.New("waitgroup wait timed out")
+)
+
+// waitWithTimeout waits for wg.Done() until timeout expires. returns errWGTimedOut if timeout expired before wg.Done() returned, otherwise returns nil. this func is naturally leaky if wg.Done() never returns
+func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		wg.Wait()
+	}()
+	select {
+	case <-time.After(timeout):
+		return errWGTimedOut
+	case <-ch:
+		return nil
+	}
+}

--- a/pkg/sshd/common_test.go
+++ b/pkg/sshd/common_test.go
@@ -28,3 +28,9 @@ func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 		return nil
 	}
 }
+
+// sshSessionOutput is the output from a *(golang.org/x/crypto/ssh).Session's Output() call
+type sshSessionOutput struct {
+	outStr string
+	err    error
+}

--- a/pkg/sshd/lock_test.go
+++ b/pkg/sshd/lock_test.go
@@ -1,7 +1,6 @@
 package sshd
 
 import (
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -12,25 +11,6 @@ import (
 const (
 	callbackTimeout = 1 * time.Second
 )
-
-var (
-	errWGTimedOut = errors.New("waitgroup wait timed out")
-)
-
-// waitWithTimeout waits for wg.Done() until timeout expires. returns errWGTimedOut if timeout expired before wg.Done() returned, otherwise returns nil. this func is naturally leaky if wg.Done() never returns
-func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
-	ch := make(chan struct{})
-	go func() {
-		defer close(ch)
-		wg.Wait()
-	}()
-	select {
-	case <-time.After(timeout):
-		return errWGTimedOut
-	case <-ch:
-		return nil
-	}
-}
 
 func TestMultipleSameRepoLocks(t *testing.T) {
 	var wg sync.WaitGroup

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -180,9 +180,9 @@ func sendExitStatus(status uint32, channel ssh.Channel) error {
 	return err
 }
 
-func (s *server) withCleanerRLock(f func() error) error {
-	s.cleanerRef.RLock()
-	defer s.cleanerRef.RUnlock()
+func (s *server) withCleanerLock(f func() error) error {
+	s.cleanerRef.Lock()
+	defer s.cleanerRef.Unlock()
 	return f()
 }
 
@@ -240,7 +240,7 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 
 				repoName := parts[1]
 				errConcurrentPush := errors.New("concurrent push")
-				err := s.withCleanerRLock(func() error {
+				err := s.withCleanerLock(func() error {
 					if err := s.pushLock.Lock(repoName, time.Duration(0)); err != nil {
 						return errConcurrentPush
 					}

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -31,8 +31,6 @@ const (
 	ServerConfig string = "ssh.ServerConfig"
 
 	multiplePush string = "Another git push is ongoing"
-
-	inProgressDelete string = "This app was deleted and is being cleaned up. Please re-create it with 'deis create your_app'"
 )
 
 // Serve starts a native SSH server.

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -232,7 +232,7 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 				}
 
 				repoName := parts[1]
-				s.cleanerRef.Lock()
+				s.cleanerRef.RLock()
 				if err := s.pushLock.Lock(repoName, time.Duration(0)); err != nil {
 					log.Errf(s.c, multiplePush)
 					// The error must be in git format
@@ -241,7 +241,7 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 					}
 					sendExitStatus(1, channel)
 					req.Reply(false, nil)
-					s.cleanerRef.Unlock()
+					s.cleanerRef.RUnlock()
 					return nil
 				}
 
@@ -258,7 +258,7 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, sshCo
 					// TODO: this is an important error case that needs to be covered
 					// Probably the best solution is to change the lock into a lease so that even on unlock failures, RepositoryLock will eventually yield
 				}
-				s.cleanerRef.Unlock()
+				s.cleanerRef.RUnlock()
 				var xs uint32
 				if err != nil {
 					log.Errf(s.c, "Failed git receive: %v", err)

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -197,7 +197,7 @@ func TestManyConcurrentPushes(t *testing.T) {
 			assert.Equal(t, string(out), "OK", "output")
 		}(repoName)
 	}
-	wg.Wait()
+	assert.NoErr(t, waitWithTimeout(&wg, 1*time.Second))
 }
 
 func TestDelete(t *testing.T) {

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -177,8 +177,6 @@ func TestManyConcurrentPushes(t *testing.T) {
 	// Connect to the server and issue env var set. This should return true.
 	client, err := ssh.Dial("tcp", testingServerAddr, &ssh.ClientConfig{})
 	assert.NoErr(t, err)
-	sess, err := client.NewSession()
-	assert.NoErr(t, err)
 
 	const numRepos = 20
 	repoNames := make([]string, numRepos)
@@ -190,7 +188,7 @@ func TestManyConcurrentPushes(t *testing.T) {
 		wg.Add(1)
 		go func(repoName string) {
 			defer wg.Done()
-			sess, err = client.NewSession()
+			sess, err := client.NewSession()
 			assert.NoErr(t, err)
 			out, err := sess.Output("git-upload-pack /" + repoName + ".git")
 			assert.NoErr(t, err)

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -172,19 +172,22 @@ func TestConcurrentPushSameRepo(t *testing.T) {
 	for i := 0; i < numPushers; i++ {
 		select {
 		case sessOut := <-outCh:
-			if sessOut.outStr != multiPushLine && sessOut.outStr != "OK" {
-				t.Fatalf("expected 'OK' or '%s', but got '%s' (error '%s')", multiPushLine, sessOut.outStr, sessOut.err)
+			output := sessOut.outStr
+			err := sessOut.err
+			if output != multiPushLine && output != "OK" {
+				t.Fatalf("expected 'OK' or '%s', but got '%s' (error '%s')", multiPushLine, output, err)
 			}
 
-			if sessOut.outStr == "OK" && sessOut.err != nil {
-				t.Fatalf("found 'OK' output with an error %s", err)
+			if sessOut.err != nil {
+				t.Fatalf("found '%s' output with an error '%s'", output, err)
 			}
 
-			if !foundOK && sessOut.outStr == "OK" {
+			if !foundOK && output == "OK" {
 				foundOK = true
-			} else if sessOut.outStr == "OK" {
-				t.Fatalf("found second OK when shouldn't have")
+			} else if output == "OK" {
+				t.Fatalf("found second 'OK' when shouldn't have")
 			}
+
 		case <-time.After(to):
 			t.Fatalf("didn't receive an output within %s", to)
 		}

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -198,6 +198,22 @@ func TestManyConcurrentPushes(t *testing.T) {
 	assert.NoErr(t, waitWithTimeout(&wg, 1*time.Second))
 }
 
+func TestWithCleanerLock(t *testing.T) {
+	srv := &server{cleanerRef: cleaner.NewRef()}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			err := srv.withCleanerLock(func() error {
+				wg.Done()
+				return nil
+			})
+			assert.NoErr(t, err)
+		}(i)
+	}
+	assert.NoErr(t, waitWithTimeout(&wg, 1*time.Second))
+}
+
 func TestDelete(t *testing.T) {
 	const testingServerAddr = "127.0.0.1:2246"
 	key, err := sshTestingHostKey()

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -130,6 +130,8 @@ func TestPushInvalidArgsLength(t *testing.T) {
 
 // TestConcurrentPushSameRepo tests many concurrent pushes, each to the same repo
 func TestConcurrentPushSameRepo(t *testing.T) {
+	t.Skip("skipping because the global lock prevents testing the repository lock, for multiple concurrent pushes to the same repo")
+	t.SkipNow()
 	const testingServerAddr = "127.0.0.1:2245"
 	key, err := sshTestingHostKey()
 	assert.NoErr(t, err)


### PR DESCRIPTION
This PR expands test coverage, mainly to the `./pkg/sshd` package. Additionally, it pulls out the cleaner locking logic to a `withCleanerLock` func in `/pkg/sshd/server.go`

Highlights of the added/improved tests:

- A test for concurrent pushes, each to a separate repository
- Improving the previously-named `TestPush` test to attempt a larger number of concurrent pushes to the same repo. This test is currently skipped (with `t.SkipNow()`) and should be enabled after #209 is merged 
- Improvements to speed up tests in `server_test.go` by removing the sleep in the SSH handler func