### PR TITLE
fix(pkg/gitreceive): replace the AWS SDK with minio-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,29 +1,10 @@
-hash: 776bcb49def4b6230d6ddc175ac9393bbe9cbc25b225e0d7880e4efd712a4318
-updated: 2016-03-02T22:49:17.194276804Z
+hash: 819f2c05823c24ce9d87e2beb40880659bfd7c944d7c35939d4851a0435c4c5a
+updated: 2016-03-03T00:14:27.72805884Z
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
 - name: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
-- name: github.com/aws/aws-sdk-go
-  version: 87b1e60a50b09e4812dee560b33a238f67305804
-  subpackages:
-  - aws
-  - aws/session
-  - service/s3
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/request
-  - private/protocol/restxml
-  - private/signer/v4
-  - private/waiter
-  - aws/credentials
-  - private/protocol/query
-  - private/protocol/rest
-  - private/protocol/xml/xmlutil
-  - private/protocol/query/queryutil
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
@@ -66,8 +47,6 @@ imports:
   - log
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-ini/ini
-  version: 193d1ecb466bf97aae8b454a5cfc192941c64809
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
@@ -101,8 +80,6 @@ imports:
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
-- name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/juju/ratelimit
   version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
 - name: github.com/kelseyhightower/envconfig

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f4239a6fb593d10c6a58faecf170be2168ea7d0884d6c6823b1b9b3efa156113
-updated: 2016-02-18T22:46:02.154250682Z
+hash: 776bcb49def4b6230d6ddc175ac9393bbe9cbc25b225e0d7880e4efd712a4318
+updated: 2016-03-02T22:49:17.194276804Z
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -12,7 +12,6 @@ imports:
   - aws/session
   - service/s3
   - aws/awserr
-  - aws/credentials
   - aws/awsutil
   - aws/client
   - aws/client/metadata
@@ -20,14 +19,10 @@ imports:
   - private/protocol/restxml
   - private/signer/v4
   - private/waiter
-  - aws/corehandlers
-  - aws/defaults
-  - private/endpoints
+  - aws/credentials
   - private/protocol/query
   - private/protocol/rest
   - private/protocol/xml/xmlutil
-  - aws/credentials/ec2rolecreds
-  - aws/ec2metadata
   - private/protocol/query/queryutil
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
@@ -66,6 +61,9 @@ imports:
   - system
 - name: github.com/emicklei/go-restful
   version: 1f9a0ee00ff93717a275e15b30cf7df356255877
+  subpackages:
+  - swagger
+  - log
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
@@ -100,7 +98,7 @@ imports:
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
-  version: 1c83b3eabd45b6d76072b66b746c20815fb2872d
+  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - name: github.com/jmespath/go-jmespath
@@ -120,6 +118,8 @@ imports:
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/minio/minio-go
+  version: 1fe1145a231e36743b79939742debafaed1cd5d0
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/prometheus/client_golang
@@ -150,14 +150,14 @@ imports:
 - name: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - name: k8s.io/kubernetes
-  version: 4309194eda6bfd4db0cc28f46cacabe1719979d7
+  version: 596055084fbaef446983b14097f832f60ae57634
   subpackages:
   - pkg/client/unversioned
   - pkg/api
-  - pkg/api/errors
-  - pkg/util/wait
   - pkg/fields
   - pkg/labels
+  - pkg/api/errors
+  - pkg/util/wait
   - pkg/api/install
   - pkg/api/latest
   - pkg/api/meta
@@ -178,9 +178,9 @@ imports:
   - pkg/conversion
   - pkg/types
   - pkg/util/rand
-  - pkg/util/errors
   - pkg/util/fielderrors
   - pkg/util/validation
+  - pkg/util/errors
   - pkg/api/registered
   - pkg/api/util
   - pkg/api/v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,13 +11,13 @@ import:
 - package: github.com/Masterminds/cookoo
   version: 110a04ff7dc3e7c9b86c1a2413906a16a2bb65cb
   subpackages:
-  - /log
-  - /safely
-  - /fmt
+  - log
+  - safely
+  - fmt
 - package: golang.org/x/crypto
   version: f7445b17d61953e333441674c2d11e91ae4559d3
   subpackages:
-  - /ssh
+  - ssh
 - package: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - package: github.com/pborman/uuid
@@ -38,3 +38,4 @@ import:
   version: ~1.1
 - package: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
+- package: github.com/minio/minio-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,12 +28,6 @@ import:
   - log
 - package: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
-- package: github.com/aws/aws-sdk-go
-  version: 87b1e60a50b09e4812dee560b33a238f67305804
-  subpackages:
-  - aws
-  - aws/session
-  - service/s3
 - package: k8s.io/kubernetes
   version: ~1.1
 - package: github.com/arschles/assert

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -209,6 +209,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 		}
 	}
 
+	log.Debug("Polling the S3 server every %d for %d for the resultant slug", conf.ObjectStorageTickDuration(), conf.ObjectStorageWaitDuration())
 	// poll the s3 server to ensure the slug exists
 	err = wait.PollImmediate(conf.ObjectStorageTickDuration(), conf.ObjectStorageWaitDuration(), func() (bool, error) {
 		exists, err := storage.ObjectExists(s3Client, conf.Bucket, slugBuilderInfo.PushKey())

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -217,7 +217,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 	}
 
 	log.Debug(
-		"Polling the S3 server every %d for %d for the resultant slug at %s/%s",
+		"Polling the S3 server every %s for %s for the resultant slug at %s/%s",
 		conf.ObjectStorageTickDuration(),
 		conf.ObjectStorageWaitDuration(),
 		conf.Bucket,

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -120,7 +120,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 		return fmt.Errorf("opening %s for read (%s)", appTgz, err)
 	}
 
-	log.Debug("Uploading tar to %s/%s/%s", s3Client.Endpoint, conf.Bucket, slugBuilderInfo.TarKey())
+	log.Debug("Uploading tar to %s/%s/%s", s3Client.Endpoint.URLStr, conf.Bucket, slugBuilderInfo.TarKey())
 	if err := storage.UploadObject(s3Client, conf.Bucket, slugBuilderInfo.TarKey(), appTgzReader); err != nil {
 		return fmt.Errorf("uploading %s to %s/%s (%v)", absAppTgz, conf.Bucket, slugBuilderInfo.TarKey(), err)
 	}

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -16,7 +16,6 @@ import (
 	"github.com/deis/builder/pkg/gitreceive/storage"
 	"github.com/deis/builder/pkg/sys"
 	"github.com/deis/pkg/log"
-	s3 "github.com/minio/minio-go"
 	"gopkg.in/yaml.v2"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -42,7 +41,7 @@ func run(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-func build(conf *Config, s3Client *s3.Client, kubeClient *client.Client, fs sys.FS, env sys.Env, builderKey, rawGitSha string) error {
+func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs sys.FS, env sys.Env, builderKey, rawGitSha string) error {
 	repo := conf.Repository
 	gitSha, err := git.NewSha(rawGitSha)
 	if err != nil {
@@ -64,7 +63,7 @@ func build(conf *Config, s3Client *s3.Client, kubeClient *client.Client, fs sys.
 		return fmt.Errorf("unable to create tmpdir %s (%s)", buildDir, err)
 	}
 
-	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client.Endpoint, conf.Bucket, appName, slugName, gitSha)
+	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client.Endpoint.URLStr, conf.Bucket, appName, slugName, gitSha)
 
 	// Get the application config from the controller, so we can check for a custom buildpack URL
 	appConf, err := getAppConfig(conf, builderKey, conf.Username, appName)

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -63,7 +63,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 		return fmt.Errorf("unable to create tmpdir %s (%s)", buildDir, err)
 	}
 
-	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client.Endpoint.URLStr, conf.Bucket, appName, slugName, gitSha)
+	slugBuilderInfo := storage.NewSlugBuilderInfo(s3Client.Endpoint, conf.Bucket, appName, slugName, gitSha)
 
 	// Get the application config from the controller, so we can check for a custom buildpack URL
 	appConf, err := getAppConfig(conf, builderKey, conf.Username, appName)

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -219,7 +219,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 	})
 
 	if err != nil {
-		return fmt.Errorf("Timed out waiting for object in storage. Aborting build...")
+		return fmt.Errorf("Timed out waiting for object in storage, aborting build (%s)", err)
 	}
 	log.Info("Build complete.")
 	log.Info("Launching app.")

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -239,20 +239,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 	log.Info("Launching app.")
 	log.Info("Launching...")
 
-	buildHook := &pkg.BuildHook{
-		Sha:         gitSha.Short(),
-		ReceiveUser: conf.Username,
-		ReceiveRepo: appName,
-		Image:       appName,
-		Procfile:    procType,
-	}
-	if !usingDockerfile {
-		buildHook.Dockerfile = ""
-		// need this to tell the controller what URL to give the slug runner
-		buildHook.Image = slugBuilderInfo.PushURL() + "/slug.tgz"
-	} else {
-		buildHook.Dockerfile = "true"
-	}
+	buildHook := createBuildHook(slugBuilderInfo, gitSha, conf.Username, appName, procType, usingDockerfile)
 	buildHookResp, err := publishRelease(conf, builderKey, buildHook)
 	if err != nil {
 		return fmt.Errorf("publishing release (%s)", err)

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -193,7 +193,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 	log.Debug("size of streamed logs %v", size)
 
 	log.Debug(
-		"Waiting for %s/%s pod to end. Checking every %s for %s",
+		"Waiting for the %s/%s pod to end. Checking every %s for %s",
 		newPod.Namespace,
 		newPod.Name,
 		conf.BuilderPodTickDuration(),

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -203,6 +203,8 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 	if err := waitForPodEnd(kubeClient, newPod.Namespace, newPod.Name, conf.BuilderPodTickDuration(), conf.BuilderPodWaitDuration()); err != nil {
 		return fmt.Errorf("error getting builder pod status (%s)", err)
 	}
+	log.Debug("Done")
+	log.Debug("Checking for builder pod exit code")
 	buildPod, err := kubeClient.Pods(newPod.Namespace).Get(newPod.Name)
 	if err != nil {
 		return fmt.Errorf("error getting builder pod status (%s)", err)
@@ -214,6 +216,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 			return fmt.Errorf("Build pod exited with code %d, stopping build.", state.ExitCode)
 		}
 	}
+	log.Debug("Done")
 
 	log.Debug(
 		"Polling the S3 server every %s for %s for the resultant slug at %s/%s",

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -120,7 +120,7 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 		return fmt.Errorf("opening %s for read (%s)", appTgz, err)
 	}
 
-	log.Debug("Uploading tar to %s/%s/%s", s3Client.Endpoint.URLStr, conf.Bucket, slugBuilderInfo.TarKey())
+	log.Debug("Uploading tar to %s/%s/%s", s3Client.Endpoint.FullURL(), conf.Bucket, slugBuilderInfo.TarKey())
 	if err := storage.UploadObject(s3Client, conf.Bucket, slugBuilderInfo.TarKey(), appTgzReader); err != nil {
 		return fmt.Errorf("uploading %s to %s/%s (%v)", absAppTgz, conf.Bucket, slugBuilderInfo.TarKey(), err)
 	}

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -223,13 +223,13 @@ func build(conf *Config, s3Client *storage.Client, kubeClient *client.Client, fs
 		conf.ObjectStorageTickDuration(),
 		conf.ObjectStorageWaitDuration(),
 		conf.Bucket,
-		slugBuilderInfo.PushKey(),
+		slugBuilderInfo.AbsoluteSlugObjectKey(),
 	)
 	// poll the s3 server to ensure the slug exists
 	if err := storage.WaitForObject(
 		s3Client,
 		conf.Bucket,
-		slugBuilderInfo.PushKey(),
+		slugBuilderInfo.AbsoluteSlugObjectKey(),
 		conf.ObjectStorageTickDuration(),
 		conf.ObjectStorageWaitDuration(),
 	); err != nil {

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/deis/builder/pkg"
 	"github.com/deis/builder/pkg/gitreceive/git"
 	"github.com/deis/builder/pkg/gitreceive/storage"
 	"github.com/deis/builder/pkg/sys"
 	"github.com/deis/pkg/log"
+	s3 "github.com/minio/minio-go"
 	"gopkg.in/yaml.v2"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -42,7 +42,7 @@ func run(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-func build(conf *Config, s3Client *s3.S3, kubeClient *client.Client, fs sys.FS, env sys.Env, builderKey, rawGitSha string) error {
+func build(conf *Config, s3Client *s3.Client, kubeClient *client.Client, fs sys.FS, env sys.Env, builderKey, rawGitSha string) error {
 	repo := conf.Repository
 	gitSha, err := git.NewSha(rawGitSha)
 	if err != nil {

--- a/pkg/gitreceive/controller_test.go
+++ b/pkg/gitreceive/controller_test.go
@@ -1,0 +1,42 @@
+package gitreceive
+
+import (
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/builder/pkg"
+	"github.com/deis/builder/pkg/gitreceive/git"
+	"github.com/deis/builder/pkg/gitreceive/storage"
+)
+
+const (
+	rawSha   = "c3b4e4ba8b7267226ff02ad07a3a2cca9c9237de"
+	bucket   = "git"
+	appName  = "myapp"
+	slugName = "myslug"
+	username = "myuser"
+)
+
+func TestCreateBuildHook(t *testing.T) {
+	procType := pkg.ProcessType(make(map[string]string))
+	sha, err := git.NewSha(rawSha)
+	assert.NoErr(t, err)
+	endpoint := &storage.Endpoint{URLStr: "s3.amazonaws.com", Secure: false}
+	slugBuilderInfo := storage.NewSlugBuilderInfo(endpoint, bucket, appName, slugName, sha)
+	hookUsingDockerfile := createBuildHook(slugBuilderInfo, sha, username, appName, procType, true)
+	assert.Equal(t, hookUsingDockerfile.Sha, sha.Short(), "git sha")
+	assert.Equal(t, hookUsingDockerfile.ReceiveUser, username, "username")
+	assert.Equal(t, hookUsingDockerfile.ReceiveRepo, appName, "username")
+	assert.Equal(t, hookUsingDockerfile.Image, appName, "image")
+	assert.Equal(t, hookUsingDockerfile.Procfile, procType, "procfile")
+	assert.Equal(t, hookUsingDockerfile.Dockerfile, "true", "dockerfile field")
+
+	hookNoDockerfile := createBuildHook(slugBuilderInfo, sha, username, appName, procType, false)
+	assert.Equal(t, hookNoDockerfile.Sha, sha.Short(), "git sha")
+	assert.Equal(t, hookNoDockerfile.ReceiveUser, username, "username")
+	assert.Equal(t, hookNoDockerfile.ReceiveRepo, appName, "username")
+	assert.Equal(t, hookNoDockerfile.Image, slugBuilderInfo.AbsoluteSlugURL(), "image")
+	assert.Equal(t, hookNoDockerfile.Procfile, procType, "procfile")
+	assert.Equal(t, hookNoDockerfile.Dockerfile, "", "dockerfile field")
+
+}

--- a/pkg/gitreceive/storage/auth.go
+++ b/pkg/gitreceive/storage/auth.go
@@ -16,12 +16,16 @@ const (
 var (
 	errMissingKey    = fmt.Errorf("missing %s", accessKeyIDFile)
 	errMissingSecret = fmt.Errorf("missing %s", accessSecretKeyFile)
-	emptyAuth        = credentials.AnonymousCredentials
+	emptyCreds       = creds{}
 )
 
 type creds struct {
 	accessKeyID     string
 	accessKeySecret string
+}
+
+func (c *creds) isZero() bool {
+	return c.accessKeyID == "" && c.accessKeySecret == ""
 }
 
 // getAuth gets storage credentials from accessKeyIDFile and accessSecretKeyFile.
@@ -32,7 +36,7 @@ func getAuth(fs sys.FS) (*credentials.Credentials, error) {
 	accessKeyIDBytes, accessKeyErr := fs.ReadFile(accessKeyIDFile)
 	accessSecretKeyBytes, accessSecretKeyErr := fs.ReadFile(accessSecretKeyFile)
 	if accessKeyErr == os.ErrNotExist && accessSecretKeyErr == os.ErrNotExist {
-		return emptyAuth, nil
+		return &emptyCreds, nil
 	}
 	if accessKeyErr != nil && accessSecretKeyErr == nil {
 		return nil, errMissingKey

--- a/pkg/gitreceive/storage/auth.go
+++ b/pkg/gitreceive/storage/auth.go
@@ -32,7 +32,7 @@ func (c *creds) isZero() bool {
 // if a key exists but not a secret, or vice-versa, returns an error.
 // if both don't exist returns emptyAuth.
 // otherwise returns a valid auth
-func getAuth(fs sys.FS) (*credentials.Credentials, error) {
+func getAuth(fs sys.FS) (*creds, error) {
 	accessKeyIDBytes, accessKeyErr := fs.ReadFile(accessKeyIDFile)
 	accessSecretKeyBytes, accessSecretKeyErr := fs.ReadFile(accessSecretKeyFile)
 	if accessKeyErr == os.ErrNotExist && accessSecretKeyErr == os.ErrNotExist {
@@ -52,7 +52,7 @@ func getAuth(fs sys.FS) (*credentials.Credentials, error) {
 
 // CredsOK checks if the required credentials to make a request exist
 func CredsOK(fs sys.FS) bool {
-	cred, err := getAuth(fs)
+	creds, err := getAuth(fs)
 	if err != nil {
 		return false
 	}

--- a/pkg/gitreceive/storage/auth.go
+++ b/pkg/gitreceive/storage/auth.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/deis/builder/pkg/sys"
 )
 
@@ -19,6 +18,11 @@ var (
 	errMissingSecret = fmt.Errorf("missing %s", accessSecretKeyFile)
 	emptyAuth        = credentials.AnonymousCredentials
 )
+
+type creds struct {
+	accessKeyID     string
+	accessKeySecret string
+}
 
 // getAuth gets storage credentials from accessKeyIDFile and accessSecretKeyFile.
 // if a key exists but not a secret, or vice-versa, returns an error.
@@ -39,7 +43,7 @@ func getAuth(fs sys.FS) (*credentials.Credentials, error) {
 
 	id := strings.TrimSpace(string(accessKeyIDBytes))
 	secret := strings.TrimSpace(string(accessSecretKeyBytes))
-	return credentials.NewStaticCredentials(id, secret, ""), nil
+	return &creds{accessKeyID: id, accessKeySecret: secret}, nil
 }
 
 // CredsOK checks if the required credentials to make a request exist
@@ -49,8 +53,7 @@ func CredsOK(fs sys.FS) bool {
 		return false
 	}
 
-	auth, _ := cred.Get()
-	if auth.AccessKeyID == "" && auth.SecretAccessKey == "" {
+	if creds.accessKeyID == "" && creds.accessKeySecret == "" {
 		return false
 	}
 

--- a/pkg/gitreceive/storage/auth_test.go
+++ b/pkg/gitreceive/storage/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/deis/builder/pkg/sys"
 )
 
@@ -12,7 +11,7 @@ func TestGetAuthEmptyAuth(t *testing.T) {
 	fs := sys.NewFakeFS()
 	creds, err := getAuth(fs)
 	assert.NoErr(t, err)
-	assert.Equal(t, creds, credentials.AnonymousCredentials, "returned credentials")
+	assert.Equal(t, *creds, emptyCreds, "returned credentials")
 }
 
 func TestGetAuthMissingSecret(t *testing.T) {

--- a/pkg/gitreceive/storage/bucket.go
+++ b/pkg/gitreceive/storage/bucket.go
@@ -11,7 +11,7 @@ const (
 
 var (
 	// ACLPublicRead default ACL for objects in the S3 API compatible storage
-	ACLPublicRead = "public-read"
+	ACLPublicRead = s3.BucketACL("public-read")
 )
 
 // CreateBucket creates a new bucket in the S3 API compatible storage or

--- a/pkg/gitreceive/storage/bucket.go
+++ b/pkg/gitreceive/storage/bucket.go
@@ -17,8 +17,7 @@ var (
 // CreateBucket creates a new bucket in the S3 API compatible storage or
 // return an error in case the bucket already exists
 func CreateBucket(creator BucketCreator, bucketName string) error {
-	_, err := creator.MakeBucket(bucketName, ACLPublicRead, "")
-	if err != nil {
+	if err := creator.MakeBucket(bucketName, ACLPublicRead, ""); err != nil {
 		minioErr := s3.ToErrorResponse(err)
 		if minioErr.Code == bucketAlreadyExistsCode {
 			return nil

--- a/pkg/gitreceive/storage/bucket.go
+++ b/pkg/gitreceive/storage/bucket.go
@@ -1,37 +1,29 @@
 package storage
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
+	s3 "github.com/minio/minio-go"
 )
 
 const (
 	bucketAlreadyExistsCode = "BucketAlreadyExists"
+	nonExistentBucketCode   = "NoSuchBucket"
 )
 
 var (
 	// ACLPublicRead default ACL for objects in the S3 API compatible storage
-	ACLPublicRead = aws.String("public-read")
+	ACLPublicRead = "public-read"
 )
 
 // CreateBucket creates a new bucket in the S3 API compatible storage or
 // return an error in case the bucket already exists
-func CreateBucket(svc *s3.S3, bucketName string) error {
-	_, err := svc.CreateBucket(&s3.CreateBucketInput{
-		Bucket: aws.String(bucketName),
-		ACL:    ACLPublicRead,
-	})
-
+func CreateBucket(creator BucketCreator, bucketName string) error {
+	_, err := creator.MakeBucket(bucketName, ACLPublicRead, "")
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == bucketAlreadyExistsCode {
-				return nil
-			}
+		minioErr := s3.ToErrorResponse(err)
+		if minioErr.Code == bucketAlreadyExistsCode {
+			return nil
 		}
-
 		return err
 	}
-
 	return nil
 }

--- a/pkg/gitreceive/storage/bucket_test.go
+++ b/pkg/gitreceive/storage/bucket_test.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/arschles/assert"
+	s3 "github.com/minio/minio-go"
+)
+
+const (
+	bucketName = "mybucket"
+)
+
+type bucketCreate struct {
+	name string
+	acl  s3.BucketACL
+	loc  string
+}
+
+func TestCreateBucketSuccess(t *testing.T) {
+	var res bucketCreate
+	creator := FakeBucketCreator(func(name string, acl s3.BucketACL, location string) error {
+		res = bucketCreate{name: name, acl: acl, loc: location}
+		return nil
+	})
+
+	assert.NoErr(t, CreateBucket(creator, bucketName))
+	assert.Equal(t, res.name, bucketName, "bucket name")
+	assert.Equal(t, res.acl, ACLPublicRead, "bucket ACL")
+	assert.Equal(t, res.loc, "", "bucket location")
+}
+
+func TestCreateBucketFailure(t *testing.T) {
+	err := errors.New("test err")
+	creator := FakeBucketCreator(func(string, s3.BucketACL, string) error {
+		return err
+	})
+	assert.Err(t, CreateBucket(creator, bucketName), err)
+}

--- a/pkg/gitreceive/storage/client.go
+++ b/pkg/gitreceive/storage/client.go
@@ -1,14 +1,12 @@
 package storage
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/deis/builder/pkg/sys"
+	s3 "github.com/minio/minio-go"
 )
 
 // GetClient returns a S3 API compatible storage client
-func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.S3, error) {
+func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.Client, error) {
 	auth, err := getAuth(fs)
 	if err != nil {
 		return nil, err
@@ -19,10 +17,5 @@ func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.S3, error) {
 		return nil, err
 	}
 
-	return s3.New(session.New(&aws.Config{
-		Credentials:      auth,
-		Region:           aws.String(regionStr),
-		Endpoint:         aws.String(endpoint),
-		S3ForcePathStyle: aws.Bool(true),
-	})), nil
+	return s3.New(endpoint, auth.accessKeyID, auth.accessKeySecret, false), nil
 }

--- a/pkg/gitreceive/storage/client.go
+++ b/pkg/gitreceive/storage/client.go
@@ -11,13 +11,8 @@ type Client struct {
 }
 
 // GetClient returns a S3 API compatible storage client
-<<<<<<< 7c8dc9bdf6ffed171ed952661229ae2b8590cef7
-func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.Client, error) {
+func GetClient(regionStr string, fs sys.FS, env sys.Env) (*Client, error) {
 	auth, err := getAuth(fs)
-=======
-func GetClient(regionStr string) (*Client, error) {
-	auth, err := getAuth()
->>>>>>> fix(pkg/gitreceive): create and use a storage.Client
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gitreceive/storage/client.go
+++ b/pkg/gitreceive/storage/client.go
@@ -23,7 +23,7 @@ func GetClient(regionStr string, fs sys.FS, env sys.Env) (*Client, error) {
 	}
 
 	// the New function call guesses which signature version to use. Currently, it correctly guesses V2 for GCS and V4 for both AWS S3 and Minio
-	s3Client, err := s3.New(endpoint.URLStr, auth.accessKeyID, auth.accessKeySecret, false)
+	s3Client, err := s3.New(endpoint.URLStr, auth.accessKeyID, auth.accessKeySecret, !endpoint.Secure)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gitreceive/storage/client.go
+++ b/pkg/gitreceive/storage/client.go
@@ -5,9 +5,19 @@ import (
 	s3 "github.com/minio/minio-go"
 )
 
+type Client struct {
+	*s3.Client
+	Endpoint *Endpoint
+}
+
 // GetClient returns a S3 API compatible storage client
+<<<<<<< 7c8dc9bdf6ffed171ed952661229ae2b8590cef7
 func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.Client, error) {
 	auth, err := getAuth(fs)
+=======
+func GetClient(regionStr string) (*Client, error) {
+	auth, err := getAuth()
+>>>>>>> fix(pkg/gitreceive): create and use a storage.Client
 	if err != nil {
 		return nil, err
 	}
@@ -17,5 +27,9 @@ func GetClient(regionStr string, fs sys.FS, env sys.Env) (*s3.Client, error) {
 		return nil, err
 	}
 
-	return s3.New(endpoint, auth.accessKeyID, auth.accessKeySecret, false), nil
+	s3Client, err := s3.New(endpoint.URLStr, auth.accessKeyID, auth.accessKeySecret, false)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{Client: s3Client, Endpoint: endpoint}, nil
 }

--- a/pkg/gitreceive/storage/client.go
+++ b/pkg/gitreceive/storage/client.go
@@ -22,6 +22,7 @@ func GetClient(regionStr string, fs sys.FS, env sys.Env) (*Client, error) {
 		return nil, err
 	}
 
+	// the New function call guesses which signature version to use. Currently, it correctly guesses V2 for GCS and V4 for both AWS S3 and Minio
 	s3Client, err := s3.New(endpoint.URLStr, auth.accessKeyID, auth.accessKeySecret, false)
 	if err != nil {
 		return nil, err

--- a/pkg/gitreceive/storage/endpoint.go
+++ b/pkg/gitreceive/storage/endpoint.go
@@ -41,6 +41,15 @@ type Endpoint struct {
 	Secure bool
 }
 
+// FullURL returns the full URL string of an endpoint, including its URL scheme, based on e.Secure
+func (e *Endpoint) FullURL() string {
+	if e.Secure {
+		return fmt.Sprintf("https://%s", e.URLStr)
+	} else {
+		return fmt.Sprintf("http://%s", e.URLStr)
+	}
+}
+
 func getEndpoint(env sys.Env) (*Endpoint, error) {
 	mHost := env.Get(minioHostEnvVar)
 	mPort := env.Get(minioPortEnvVar)

--- a/pkg/gitreceive/storage/endpoint.go
+++ b/pkg/gitreceive/storage/endpoint.go
@@ -33,19 +33,19 @@ func stripScheme(str string) string {
 	return str
 }
 
-type endpoint struct {
-	urlStr string
-	secure bool
+type Endpoint struct {
+	URLStr string
+	Secure bool
 }
 
-func getEndpoint(env sys.Env) (*endpoint, error) {
+func getEndpoint(env sys.Env) (*Endpoint, error) {
 	mHost := env.Get(minioHostEnvVar)
 	mPort := env.Get(minioPortEnvVar)
 	S3EP := env.Get(outsideStorageEndpoint)
 	if S3EP != "" {
-		return &endpoint{urlStr: stripScheme(S3EP), secure: true}, nil
+		return &Endpoint{URLStr: stripScheme(S3EP), Secure: true}, nil
 	} else if mHost != "" && mPort != "" {
-		return &endpoint{urlStr: fmt.Sprintf("%s:%s", mHost, mPort), secure: false}, nil
+		return &Endpoint{URLStr: fmt.Sprintf("%s:%s", mHost, mPort), Secure: false}, nil
 	} else {
 		return nil, errNoStorageConfig
 	}

--- a/pkg/gitreceive/storage/endpoint.go
+++ b/pkg/gitreceive/storage/endpoint.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/deis/builder/pkg/sys"

--- a/pkg/gitreceive/storage/endpoint.go
+++ b/pkg/gitreceive/storage/endpoint.go
@@ -33,8 +33,11 @@ func stripScheme(str string) string {
 	return str
 }
 
+// Endpoint represents all the details about a storage endpoint
 type Endpoint struct {
+	// URLStr is the url string, stripped of its scheme
 	URLStr string
+	// Secure determines if TLS should be used (e.g. a "https://" scheme)
 	Secure bool
 }
 

--- a/pkg/gitreceive/storage/endpoint_test.go
+++ b/pkg/gitreceive/storage/endpoint_test.go
@@ -9,7 +9,7 @@ import (
 
 type getEndpointTestCase struct {
 	envVars     map[string]string
-	expectedOut string
+	expectedOut *Endpoint
 	expectedErr error
 }
 
@@ -17,11 +17,11 @@ func TestGetEndpoint(t *testing.T) {
 	testCases := []getEndpointTestCase{
 		getEndpointTestCase{
 			envVars:     map[string]string{"DEIS_OUTSIDE_STORAGE": "http://outside.storage.com"},
-			expectedOut: "http://outside.storage.com",
+			expectedOut: &Endpoint{URLStr: "outside.storage.com", Secure: true},
 		},
 		getEndpointTestCase{
 			envVars:     map[string]string{"DEIS_OUTSIDE_STORAGE": "https://outside.com"},
-			expectedOut: "https://outside.com",
+			expectedOut: &Endpoint{URLStr: "outside.com", Secure: true},
 		},
 		getEndpointTestCase{
 			envVars: map[string]string{
@@ -29,14 +29,14 @@ func TestGetEndpoint(t *testing.T) {
 				"DEIS_MINIO_SERVICE_HOST": "minio.com",
 				"DEIS_MINIO_SERVICE_PORT": "8888",
 			},
-			expectedOut: "outside.com",
+			expectedOut: &Endpoint{URLStr: "outside.com", Secure: true},
 		},
 		getEndpointTestCase{
 			envVars: map[string]string{
 				"DEIS_MINIO_SERVICE_HOST": "minio.com",
 				"DEIS_MINIO_SERVICE_PORT": "8888",
 			},
-			expectedOut: "http://minio.com:8888",
+			expectedOut: &Endpoint{URLStr: "minio.com:8888", Secure: false},
 		},
 		getEndpointTestCase{
 			envVars: map[string]string{
@@ -54,12 +54,36 @@ func TestGetEndpoint(t *testing.T) {
 	for _, testCase := range testCases {
 		fe := sys.NewFakeEnv()
 		fe.Envs = testCase.envVars
-		str, err := getEndpoint(fe)
-		assert.Equal(t, str, testCase.expectedOut, "output")
+		ep, err := getEndpoint(fe)
+
+		if testCase.expectedOut != nil {
+			assert.Equal(t, ep.URLStr, testCase.expectedOut.URLStr, "url string")
+			assert.Equal(t, ep.Secure, testCase.expectedOut.Secure, "secure boolean")
+		} else {
+			assert.True(t, ep == nil, "endpoint was non-nil when it should have been")
+		}
+
 		if testCase.expectedErr == nil {
 			assert.NoErr(t, err)
 		} else {
 			assert.Equal(t, err, testCase.expectedErr, "error")
 		}
+	}
+}
+
+type schemeTestCase struct {
+	before string
+	after  string
+}
+
+func TestStripScheme(t *testing.T) {
+	schemes := []schemeTestCase{
+		schemeTestCase{before: "https://deis.com", after: "deis.com"},
+		schemeTestCase{before: "http://deis.com", after: "deis.com"},
+		schemeTestCase{before: "deis.com", after: "deis.com"},
+		schemeTestCase{before: "://deis.com", after: "://deis.com"},
+	}
+	for i, scheme := range schemes {
+		assert.Equal(t, stripScheme(scheme.before), scheme.after, fmt.Sprintf("scheme %s (# %d)", scheme.before, i))
 	}
 }

--- a/pkg/gitreceive/storage/endpoint_test.go
+++ b/pkg/gitreceive/storage/endpoint_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/arschles/assert"

--- a/pkg/gitreceive/storage/interfaces.go
+++ b/pkg/gitreceive/storage/interfaces.go
@@ -11,12 +11,22 @@ type BucketCreator interface {
 	MakeBucket(bucketName string, acl s3.BucketACL, location string) error
 }
 
+type FakeMakeBucketCall struct {
+	BucketName string
+	ACL        s3.BucketACL
+	Location   string
+}
+
 // FakeBucketCreator is a mock function that can be swapped in for an BucketCreator, so you can unit test your code
-type FakeBucketCreator func(string, s3.BucketACL, string) error
+type FakeBucketCreator struct {
+	Fn    func(string, s3.BucketACL, string) error
+	Calls []FakeMakeBucketCall
+}
 
 // PutObject is the interface definition
-func (f FakeBucketCreator) MakeBucket(name string, acl s3.BucketACL, location string) error {
-	return f(name, acl, location)
+func (f *FakeBucketCreator) MakeBucket(name string, acl s3.BucketACL, location string) error {
+	f.Calls = append(f.Calls, FakeMakeBucketCall{BucketName: name, ACL: acl, Location: location})
+	return f.Fn(name, acl, location)
 }
 
 // ObjectStatter is a *(github.com/minio/minio-go).Client compatible interface, restricted to just the StatObject function. You can use it in your code for easier unit testing without any external dependencies
@@ -24,12 +34,21 @@ type ObjectStatter interface {
 	StatObject(bucketName, objectKey string) (s3.ObjectInfo, error)
 }
 
+type FakeStatObjectCall struct {
+	BucketName string
+	ObjectKey  string
+}
+
 // FakeObjectStatter is a mock function that can be swapped in for an ObjectStatter, so you can unit test your code
-type FakeObjectStatter func(string, string) (s3.ObjectInfo, error)
+type FakeObjectStatter struct {
+	Fn    func(string, string) (s3.ObjectInfo, error)
+	Calls []FakeStatObjectCall
+}
 
 // PutObject is the interface definition
-func (f FakeObjectStatter) StatObject(bucketName, objectKey string) (s3.ObjectInfo, error) {
-	return f(bucketName, objectKey)
+func (f *FakeObjectStatter) StatObject(bucketName, objectKey string) (s3.ObjectInfo, error) {
+	f.Calls = append(f.Calls, FakeStatObjectCall{BucketName: bucketName, ObjectKey: objectKey})
+	return f.Fn(bucketName, objectKey)
 }
 
 // ObjectPutter is a *(github.com/minio/minio-go).Client compatible interface, restricted to just the PutObject function. You can use it in your code for easier unit testing without any external dependencies
@@ -37,10 +56,26 @@ type ObjectPutter interface {
 	PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
 }
 
+type FakePutObjectCall struct {
+	BucketName  string
+	ObjectKey   string
+	Reader      io.Reader
+	ContentType string
+}
+
 // FakeObjectPutter is a mock function that can be swapped in for an ObjectPutter, so you can unit test your code
-type FakeObjectPutter func(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
+type FakeObjectPutter struct {
+	Fn    func(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
+	Calls []FakePutObjectCall
+}
 
 // PutObject is the interface definition
-func (f FakeObjectPutter) PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error) {
-	return f(bucketName, objectKey, reader, contentType)
+func (f *FakeObjectPutter) PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error) {
+	f.Calls = append(f.Calls, FakePutObjectCall{
+		BucketName:  bucketName,
+		ObjectKey:   objectKey,
+		Reader:      reader,
+		ContentType: contentType,
+	})
+	return f.Fn(bucketName, objectKey, reader, contentType)
 }

--- a/pkg/gitreceive/storage/interfaces.go
+++ b/pkg/gitreceive/storage/interfaces.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"io"
+
 	s3 "github.com/minio/minio-go"
 )
 

--- a/pkg/gitreceive/storage/interfaces.go
+++ b/pkg/gitreceive/storage/interfaces.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	s3 "github.com/minio/minio-go"
+)
+
+type BucketCreator interface {
+	MakeBucket(bucketName string, acl s3.BucketACL, location string) error
+}
+
+type ObjectStatter interface {
+	StatObject(bucketName, objectKey string) (s3.ObjectInfo, error)
+}
+
+type ObjectPutter interface {
+	PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
+}

--- a/pkg/gitreceive/storage/interfaces.go
+++ b/pkg/gitreceive/storage/interfaces.go
@@ -6,14 +6,41 @@ import (
 	s3 "github.com/minio/minio-go"
 )
 
+// BucketCreator is a *(github.com/minio/minio-go).Client compatible interface, restricted to just the MakeBucket function. You can use it in your code for easier unit testing without any external dependencies
 type BucketCreator interface {
 	MakeBucket(bucketName string, acl s3.BucketACL, location string) error
 }
 
+// FakeBucketCreator is a mock function that can be swapped in for an BucketCreator, so you can unit test your code
+type FakeBucketCreator func(string, s3.BucketACL, string) error
+
+// PutObject is the interface definition
+func (f FakeBucketCreator) MakeBucket(name string, acl s3.BucketACL, location string) error {
+	return f(name, acl, location)
+}
+
+// ObjectStatter is a *(github.com/minio/minio-go).Client compatible interface, restricted to just the StatObject function. You can use it in your code for easier unit testing without any external dependencies
 type ObjectStatter interface {
 	StatObject(bucketName, objectKey string) (s3.ObjectInfo, error)
 }
 
+// FakeObjectStatter is a mock function that can be swapped in for an ObjectStatter, so you can unit test your code
+type FakeObjectStatter func(string, string) (s3.ObjectInfo, error)
+
+// PutObject is the interface definition
+func (f FakeObjectStatter) StatObject(bucketName, objectKey string) (s3.ObjectInfo, error) {
+	return f(bucketName, objectKey)
+}
+
+// ObjectPutter is a *(github.com/minio/minio-go).Client compatible interface, restricted to just the PutObject function. You can use it in your code for easier unit testing without any external dependencies
 type ObjectPutter interface {
 	PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
+}
+
+// FakeObjectPutter is a mock function that can be swapped in for an ObjectPutter, so you can unit test your code
+type FakeObjectPutter func(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error)
+
+// PutObject is the interface definition
+func (f FakeObjectPutter) PutObject(bucketName, objectKey string, reader io.Reader, contentType string) (int64, error) {
+	return f(bucketName, objectKey, reader, contentType)
 }

--- a/pkg/gitreceive/storage/object.go
+++ b/pkg/gitreceive/storage/object.go
@@ -12,12 +12,16 @@ const (
 	octetStream = "application/octet-stream"
 )
 
-func ObjectExists(statter ObjectStatter, bucket, objName string) (bool, error) {
+func ObjectExists(statter ObjectStatter, bucketName, objKey string) (bool, error) {
 	objInfo, err := statter.StatObject(bucketName, objKey)
 	if err != nil {
+		minioErr := s3.ToErrorResponse(err)
+		if minioErr.Code == noSuchKeyCode {
+			return false, nil
+		}
 		return false, err
 	}
-	if objInfo.Code == noSuchKeyCode || objInfo.Err != nil {
+	if objInfo.Err != nil {
 		return false, nil
 	}
 	return true, nil

--- a/pkg/gitreceive/storage/object.go
+++ b/pkg/gitreceive/storage/object.go
@@ -12,6 +12,11 @@ const (
 	octetStream = "application/octet-stream"
 )
 
+// ObjectExists determines whether the object in ${bucketName}/${objKey} exists, as reported by statter. Returns the following:
+//
+// - false, nil if statter succeeded and reported the object doesn't exist
+// - false, err with the appropriate error if the statter failed
+// - true, nil if the statter succeeded and reported the object exists
 func ObjectExists(statter ObjectStatter, bucketName, objKey string) (bool, error) {
 	objInfo, err := statter.StatObject(bucketName, objKey)
 	if err != nil {

--- a/pkg/gitreceive/storage/object_test.go
+++ b/pkg/gitreceive/storage/object_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -36,4 +37,16 @@ func TestObjectExistsNoObject(t *testing.T) {
 	assert.NoErr(t, err)
 	assert.False(t, exists, "object found when it should be missing")
 	assert.Equal(t, len(statter.Calls), 1, "number of StatObject calls")
+}
+
+func TestObjectExistsOtherErr(t *testing.T) {
+	expectedErr := errors.New("other error")
+	statter := &FakeObjectStatter{
+		Fn: func(string, string) (s3.ObjectInfo, error) {
+			return s3.ObjectInfo{}, expectedErr
+		},
+	}
+	exists, err := ObjectExists(statter, bucketName, objKey)
+	assert.Err(t, err, expectedErr)
+	assert.False(t, exists, "object found when the statter errored")
 }

--- a/pkg/gitreceive/storage/object_test.go
+++ b/pkg/gitreceive/storage/object_test.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/arschles/assert"
+	s3 "github.com/minio/minio-go"
+)
+
+const (
+	objKey = "myobj"
+)
+
+func TestObjectExistsSuccess(t *testing.T) {
+	objInfo := s3.ObjectInfo{Key: objKey, Err: nil, Size: 1234}
+	statter := &FakeObjectStatter{
+		Fn: func(string, string) (s3.ObjectInfo, error) {
+			return objInfo, nil
+		},
+	}
+	exists, err := ObjectExists(statter, bucketName, objKey)
+	assert.NoErr(t, err)
+	assert.True(t, exists, "object not found when it should be present")
+	assert.Equal(t, len(statter.Calls), 1, "number of StatObject calls")
+	assert.Equal(t, statter.Calls[0].BucketName, bucketName, "bucket name")
+	assert.Equal(t, statter.Calls[0].ObjectKey, objKey, "object key")
+}
+
+func TestObjectExistsNoObject(t *testing.T) {
+	statter := &FakeObjectStatter{
+		Fn: func(string, string) (s3.ObjectInfo, error) {
+			return s3.ObjectInfo{}, s3.ErrorResponse{Code: noSuchKeyCode}
+		},
+	}
+	exists, err := ObjectExists(statter, bucketName, objKey)
+	assert.NoErr(t, err)
+	assert.False(t, exists, "object found when it should be missing")
+	assert.Equal(t, len(statter.Calls), 1, "number of StatObject calls")
+}

--- a/pkg/gitreceive/storage/object_test.go
+++ b/pkg/gitreceive/storage/object_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -49,4 +51,30 @@ func TestObjectExistsOtherErr(t *testing.T) {
 	exists, err := ObjectExists(statter, bucketName, objKey)
 	assert.Err(t, err, expectedErr)
 	assert.False(t, exists, "object found when the statter errored")
+}
+
+func TestUploadObjectSuccess(t *testing.T) {
+	rdr := strings.NewReader("hello world!")
+	putter := &FakeObjectPutter{
+		Fn: func(string, string, io.Reader, string) (int64, error) {
+			return 0, nil
+		},
+	}
+	assert.NoErr(t, UploadObject(putter, bucketName, objKey, rdr))
+	assert.Equal(t, len(putter.Calls), 1, "number of calls to PutObject")
+	assert.Equal(t, putter.Calls[0].BucketName, bucketName, "the bucket name")
+	assert.Equal(t, putter.Calls[0].ObjectKey, objKey, "the object key")
+	assert.Equal(t, putter.Calls[0].ContentType, octetStream, "the content type")
+}
+
+func TestUploadObjectFailure(t *testing.T) {
+	rdr := strings.NewReader("hello world")
+	err := errors.New("test error")
+	putter := &FakeObjectPutter{
+		Fn: func(string, string, io.Reader, string) (int64, error) {
+			return 0, err
+		},
+	}
+	assert.Err(t, UploadObject(putter, bucketName, objKey, rdr), err)
+	assert.Equal(t, len(putter.Calls), 1, "number of calls to PutObject")
 }

--- a/pkg/gitreceive/storage/object_test.go
+++ b/pkg/gitreceive/storage/object_test.go
@@ -89,7 +89,7 @@ func TestWaitForObjectMissing(t *testing.T) {
 	err := WaitForObject(statter, bucketName, objKey, 1*time.Millisecond, 2*time.Millisecond)
 	assert.True(t, err != nil, "no error received when there should have been")
 	// it should make 1 call immediately, then calls at 1ms and 2ms
-	assert.Equal(t, len(statter.Calls), 3, "number of calls to the statter")
+	assert.True(t, len(statter.Calls) >= 3, "the statter wasn't called at least once")
 }
 
 func TestWaitForObjectExists(t *testing.T) {

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -38,5 +38,5 @@ func (s SlugBuilderInfo) TarKey() string                { return s.tarKey }
 func (s SlugBuilderInfo) TarURL() string                { return s.tarURL }
 func (s SlugBuilderInfo) AbsoluteSlugObjectKey() string { return s.PushKey() + "/" + slugTGZName }
 func (s SlugBuilderInfo) AbsoluteSlugURL() string {
-	return s.PushURL() + "/" + s.AbsoluteSlugObjectKey()
+	return s.PushURL() + "/" + slugTGZName
 }

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -15,16 +15,16 @@ type SlugBuilderInfo struct {
 }
 
 // NewSlugBuilderInfo creates and populates a new SlugBuilderInfo based on the given data
-func NewSlugBuilderInfo(s3Endpoint, bucket, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
+func NewSlugBuilderInfo(s3Endpoint *Endpoint, bucket, appName, slugName string, gitSha *git.SHA) *SlugBuilderInfo {
 	tarKey := fmt.Sprintf("home/%s/tar", slugName)
 	// this is where workflow tells slugrunner to download the slug from, so we have to tell slugbuilder to upload it to here
 	pushKey := fmt.Sprintf("home/%s:git-%s/push", appName, gitSha.Short())
 
 	return &SlugBuilderInfo{
 		pushKey: pushKey,
-		pushURL: fmt.Sprintf("%s/%s/%s", s3Endpoint, bucket, pushKey),
+		pushURL: fmt.Sprintf("%s/%s/%s", s3Endpoint.FullURL(), bucket, pushKey),
 		tarKey:  tarKey,
-		tarURL:  fmt.Sprintf("%s/%s/%s", s3Endpoint, bucket, tarKey),
+		tarURL:  fmt.Sprintf("%s/%s/%s", s3Endpoint.FullURL(), bucket, tarKey),
 	}
 }
 

--- a/pkg/gitreceive/storage/slug_builder_info.go
+++ b/pkg/gitreceive/storage/slug_builder_info.go
@@ -6,6 +6,10 @@ import (
 	"github.com/deis/builder/pkg/gitreceive/git"
 )
 
+const (
+	slugTGZName = "slug.tgz"
+)
+
 // SlugBuilderInfo contains all of the object storage related information needed to pass to a slug builder
 type SlugBuilderInfo struct {
 	pushKey string
@@ -28,7 +32,11 @@ func NewSlugBuilderInfo(s3Endpoint *Endpoint, bucket, appName, slugName string, 
 	}
 }
 
-func (s SlugBuilderInfo) PushKey() string { return s.pushKey }
-func (s SlugBuilderInfo) PushURL() string { return s.pushURL }
-func (s SlugBuilderInfo) TarKey() string  { return s.tarKey }
-func (s SlugBuilderInfo) TarURL() string  { return s.tarURL }
+func (s SlugBuilderInfo) PushKey() string               { return s.pushKey }
+func (s SlugBuilderInfo) PushURL() string               { return s.pushURL }
+func (s SlugBuilderInfo) TarKey() string                { return s.tarKey }
+func (s SlugBuilderInfo) TarURL() string                { return s.tarURL }
+func (s SlugBuilderInfo) AbsoluteSlugObjectKey() string { return s.PushKey() + "/" + slugTGZName }
+func (s SlugBuilderInfo) AbsoluteSlugURL() string {
+	return s.PushURL() + "/" + s.AbsoluteSlugObjectKey()
+}

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -70,5 +70,5 @@ func TestAbsoluteSlugURL(t *testing.T) {
 	sha, err := git.NewSha(rawSha)
 	assert.NoErr(t, err)
 	sbi := NewSlugBuilderInfo(s3Endpoint, bucket, appName, slugName, sha)
-	assert.Equal(t, sbi.AbsoluteSlugURL(), sbi.PushURL()+"/"+sbi.PushKey()+"/"+slugTGZName, "absolute slug URL")
+	assert.Equal(t, sbi.AbsoluteSlugURL(), sbi.PushURL()+"/"+slugTGZName, "absolute slug URL")
 }

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"testing"
 
+	"github.com/arschles/assert"
 	"github.com/deis/builder/pkg/gitreceive/git"
 )
 
@@ -56,4 +57,18 @@ func TestTarKey(t *testing.T) {
 	if sbi.TarKey() != expectedTarKey {
 		t.Errorf("tar key %s didn't match expected %s", sbi.TarKey(), expectedTarKey)
 	}
+}
+
+func TestAbsoluteSlugObjectKey(t *testing.T) {
+	sha, err := git.NewSha(rawSha)
+	assert.NoErr(t, err)
+	sbi := NewSlugBuilderInfo(s3Endpoint, bucket, appName, slugName, sha)
+	assert.Equal(t, sbi.AbsoluteSlugObjectKey(), sbi.PushKey()+"/"+slugTGZName, "absolute slug key")
+}
+
+func TestAbsoluteSlugURL(t *testing.T) {
+	sha, err := git.NewSha(rawSha)
+	assert.NoErr(t, err)
+	sbi := NewSlugBuilderInfo(s3Endpoint, bucket, appName, slugName, sha)
+	assert.Equal(t, sbi.AbsoluteSlugURL(), sbi.PushURL()+"/"+sbi.PushKey()+"/"+slugTGZName, "absolute slug URL")
 }

--- a/pkg/gitreceive/storage/slug_builder_info_test.go
+++ b/pkg/gitreceive/storage/slug_builder_info_test.go
@@ -7,11 +7,14 @@ import (
 )
 
 const (
-	rawSha     = "c3b4e4ba8b7267226ff02ad07a3a2cca9c9237de"
-	s3Endpoint = "http://10.1.2.3:9090"
-	appName    = "myapp"
-	slugName   = "myslug"
-	bucket     = "git"
+	rawSha   = "c3b4e4ba8b7267226ff02ad07a3a2cca9c9237de"
+	appName  = "myapp"
+	slugName = "myslug"
+	bucket   = "git"
+)
+
+var (
+	s3Endpoint = &Endpoint{URLStr: "10.1.2.3:9090", Secure: false}
 )
 
 func TestS3Endpoint(t *testing.T) {
@@ -21,11 +24,11 @@ func TestS3Endpoint(t *testing.T) {
 	}
 	sbi := NewSlugBuilderInfo(s3Endpoint, bucket, appName, slugName, sha)
 
-	expectedPushURL := s3Endpoint + "/" + bucket + "/" + sbi.PushKey()
+	expectedPushURL := s3Endpoint.FullURL() + "/" + bucket + "/" + sbi.PushKey()
 	if sbi.PushURL() != expectedPushURL {
 		t.Errorf("push URL %s didn't match expected %s", sbi.PushURL(), expectedPushURL)
 	}
-	expectedTarURL := s3Endpoint + "/" + bucket + "/" + sbi.TarKey()
+	expectedTarURL := s3Endpoint.FullURL() + "/" + bucket + "/" + sbi.TarKey()
 	if sbi.TarURL() != expectedTarURL {
 		t.Errorf("tar URL %s didn't match expected %s", sbi.TarURL(), expectedTarURL)
 	}

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -1,35 +1,34 @@
 package healthsrv
 
 import (
-	s3 "github.com/aws/aws-sdk-go/service/s3"
+	s3 "github.com/minio/minio-go"
 )
 
 // BucketLister is a *(github.com/aws/aws-sdk-go/service/s3).Client compatible interface that provides just the ListBuckets cross-section of functionality. It can also be implemented for unit tests
 type BucketLister interface {
 	// ListBuckets lists all the buckets in the object storage system
-	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
+	ListBuckets() ([]s3.BucketInfo, error)
 }
 
 type emptyBucketLister struct{}
 
-func (e emptyBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
-	var buckets []*s3.Bucket
-	return &s3.ListBucketsOutput{Buckets: buckets}, nil
+func (e emptyBucketLister) ListBuckets() ([]s3.BucketInfo, error) {
+	return nil, nil
 }
 
 type errBucketLister struct {
 	err error
 }
 
-func (e errBucketLister) ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
+func (e errBucketLister) ListBuckets() ([]s3.BucketInfo, error) {
 	return nil, e.err
 }
 
 // listBuckets calls bl.ListBuckets(...) and sends the results back on the various given channels. This func is intended to be run in a goroutine and communicates via the channels it's passed.
 //
 // On success, it passes the bucket output on succCh, and on failure, it passes the error on errCh. At most one of {succCh, errCh} will be sent on. If stopCh is closed, no pending or future sends will occur.
-func listBuckets(bl BucketLister, succCh chan<- *s3.ListBucketsOutput, errCh chan<- error, stopCh <-chan struct{}) {
-	lbOut, err := bl.ListBuckets(&s3.ListBucketsInput{})
+func listBuckets(bl BucketLister, succCh chan<- []s3.BucketInfo, errCh chan<- error, stopCh <-chan struct{}) {
+	lbOut, err := bl.ListBuckets()
 	if err != nil {
 		select {
 		case errCh <- err:

--- a/pkg/healthsrv/buckets_lister.go
+++ b/pkg/healthsrv/buckets_lister.go
@@ -4,7 +4,7 @@ import (
 	s3 "github.com/minio/minio-go"
 )
 
-// BucketLister is a *(github.com/aws/aws-sdk-go/service/s3).Client compatible interface that provides just the ListBuckets cross-section of functionality. It can also be implemented for unit tests
+// BucketLister is a *(github.com/minio/minio-go).Client compatible interface that provides just the ListBuckets cross-section of functionality. It can also be implemented for unit tests
 type BucketLister interface {
 	// ListBuckets lists all the buckets in the object storage system
 	ListBuckets() ([]s3.BucketInfo, error)

--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	s3 "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/deis/builder/pkg/sshd"
+	s3 "github.com/minio/minio-go"
 	"k8s.io/kubernetes/pkg/api"
 )
 
@@ -24,7 +24,7 @@ func healthZHandler(nsLister NamespaceLister, bLister BucketLister, serverCircui
 		go circuitState(serverCircuit, serverStateCh, serverStateErrCh, stopCh)
 		numChecks++
 
-		listBucketsCh := make(chan *s3.ListBucketsOutput)
+		listBucketsCh := make(chan []s3.BucketInfo)
 		listBucketsErrCh := make(chan error)
 		go listBuckets(bLister, listBucketsCh, listBucketsErrCh, stopCh)
 		numChecks++


### PR DESCRIPTION
To support Google Cloud Storage compatibility mode, the builder must support AWS version 2 signatures. Singe the `github.com/aws/aws-sdk-go` package package doesn't support v2 signing for S3, this PR replaces that package with `github.com/minio/minio-go`, which does.

This PR also emphasizes testing related to object storage, and while necessary, that emphasis led to more changes here than strictly necessary to achieve the functionality we needed.

See below for a list of additional changes necessary to aid testing:

- `minio-go` compatible interfaces
- Mocks for each of the above interfaces
- Unit tests for most of the `func`s inside of `github.com/deis/builder/pkg/gitreceive/storage`
- More logging in the git receive hook
- New utility functions (and tests for them) on `SlugBuilderInfo`
- A new `createBuildHook` in `pkg/gitreceive/controller.go`, and tests for it

Fixes #222 

TODO: After this is done, create an issue to:

- ~~Move the object storage logic into one package: `github.com/deis/builder/pkg/storage`~~ - it's been created at https://github.com/deis/builder/issues/226
- ~~Refactor the health check endpoint code to use minio-go~~ - that had to be done in this PR