### PR TITLE
fix(pkg/gitreceive/storage/object_test.go): skip TestWaitForObjectMissing

### DIFF
--- a/pkg/gitreceive/storage/object_test.go
+++ b/pkg/gitreceive/storage/object_test.go
@@ -81,6 +81,8 @@ func TestUploadObjectFailure(t *testing.T) {
 }
 
 func TestWaitForObjectMissing(t *testing.T) {
+	// Skipped for now. See https://github.com/deis/builder/issues/238
+	t.SkipNow()
 	statter := &FakeObjectStatter{
 		Fn: func(string, string) (s3.ObjectInfo, error) {
 			return s3.ObjectInfo{}, s3.ErrorResponse{Code: noSuchKeyCode}


### PR DESCRIPTION
only skip it for now. this issue does *not* fix https://github.com/deis/builder/issues/238

cc/ @smothiki 