### PR TITLE
doc(PULL_REQUEST_TEMPLATE): fix commit style guideline link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -47,4 +47,4 @@ Please make sure the below checklist is complete.
 
 - [ ] Your pull request is concise and to the point (make another PR for refactoring nearby code)
 - [ ] Your commits are squashed into logical units of work
-- [ ] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards.html#commit-style)
+- [ ] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)


### PR DESCRIPTION
# Summary of Changes

This PR fixes the link to the commit style guidelines in the Pull Request Template file

# Issue(s) that this PR Closes

References https://github.com/deis/workflow/issues/131

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

None

# Associated [Documentation](https://github.com/deis/docs-v2) PR(s)

None

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

None

# Testing Instructions

None. This is a documentation-only change.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards.html#commit-style)