### PR TITLE
feat(progress):print status to avoid losing session

### DIFF
--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	BuilderPodWaitDurationMSec    int    `envconfig:"BUILDER_POD_WAIT_DURATION" default:"900000"` // 15 minutes
 	ObjectStorageTickDurationMSec int    `envconfing:"OBJECT_STORAGE_TICK_DURATION" default:"500"`
 	ObjectStorageWaitDurationMSec int    `envconfig:"OBJECT_STORAGE_WAIT_DURATION" default:"300000"` // 5 minutes
+	SessionIdleIntervalMsec       int    `envconfig:"SESSION_IDLE_INTERVAL" default:"10000"`         // 10 seconds
 	SlugBuilderImage              string `envconfig:"SLUGBUILDER_IMAGE_NAME" default:"quay.io/deisci/slugbuilder:v2-beta"`
 	DockerBuilderImage            string `envconfig:"DOCKERBUILDER_IMAGE_NAME" default:"quay.io/deisci/dockerbuilder:v2-beta"`
 	SlugBuilderImagePullPolicy    string `envconfig:"SLUG_BUILDER_IMAGE_PULL_POLICY" default:"Always"`
@@ -71,6 +72,11 @@ func (c Config) ObjectStorageTickDuration() time.Duration {
 // operation that involves the object storage.
 func (c Config) ObjectStorageWaitDuration() time.Duration {
 	return time.Duration(time.Duration(c.ObjectStorageWaitDurationMSec) * time.Millisecond)
+}
+
+// SessionIdleInterval returns the ticker interval to wait for status
+func (c Config) SessionIdleInterval() time.Duration {
+	return time.Duration(time.Duration(c.SessionIdleIntervalMsec) * time.Millisecond)
 }
 
 // CheckDurations checks if ticks for builder and object storage are not bigger


### PR DESCRIPTION
# Summary of Changes

This PR adds and new function called progress which prints the message passed to it for every 8 seconds . This avoids session end and remote end hung up errors for builder while waiting to build or pull large images or if the network bandwidth is less. 

# Issue(s) that this PR Closes
Closes https://github.com/deis/builder/issues/268

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)






# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register a build pack or any app
3. do git push deis master

Also, please provide a description of the desired result after the tester completes the above steps.
```
    ],
    "restartPolicy": "Never",
    "serviceAccountName": ""
  },
  "status": {}
}

waiting for the pod to come up ...
waiting for the pod to come up ...
download tar file complete
extracting tar file complete
Step 1 : FROM alpine:3.1
 ---> bdf8036b1c64
----------
---------

waiting for controller to launch App...
Launching App ...
Done, casual-sculptor:v2 deployed to Deis

Use 'deis open' to view this application in your browser

To learn more, use 'deis help' or visit http://deis.io
```
```
    "restartPolicy": "Never",
    "serviceAccountName": ""
  },
  "status": {}
}

waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
waiting for the pod to come up ...
```

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)