### PR TITLE
feat(storage): remove polling for object in storage

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -226,24 +226,6 @@ func build(
 	}
 	log.Debug("Done")
 
-	log.Debug(
-		"Polling the S3 server every %s for %s for the resultant slug at %s",
-		conf.ObjectStorageTickDuration(),
-		conf.ObjectStorageWaitDuration(),
-		slugBuilderInfo.AbsoluteSlugObjectKey(),
-	)
-	// poll the s3 server to ensure the slug exists
-	if !usingDockerfile {
-		if err := storage.WaitForObject(
-			storageDriver,
-			slugBuilderInfo.AbsoluteSlugObjectKey(),
-			conf.ObjectStorageTickDuration(),
-			conf.ObjectStorageWaitDuration(),
-		); err != nil {
-			return fmt.Errorf("Timed out waiting for object in storage, aborting build (%s)", err)
-		}
-	}
-
 	procType := pkg.ProcessType{}
 	if bType == buildTypeProcfile {
 		if procType, err = getProcFile(storageDriver, tmpDir, slugBuilderInfo.AbsoluteProcfileKey()); err != nil {


### PR DESCRIPTION
# Summary of Changes

This PR avoid builder to poll for object storage if the file were uploaded or not


Ref https://github.com/deis/slugrunner/pull/26
Ref https://github.com/deis/slugbuilder/pull/52


# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. Your Steps Here...

Also, please provide a description of the desired result after the tester completes the above steps.

1. The app called "abcd" should be deployed
2. `kubectl get pod --namespace=abcd` should show 2 pods running
3. etc...

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)