### PR TITLE
fix(pkg/git/git.go): fix blank image pull policy

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -31,7 +31,14 @@ strip_remote_prefix() {
     stdbuf -i0 -o0 -e0 sed "s/^/"$'\e[1G'"/"
 }
 
-GIT_HOME={{.GitHome}} boot git-receive | strip_remote_prefix
+GIT_HOME={{.GitHome}} \
+SSH_CONNECTION="$SSH_CONNECTION" \
+SSH_ORIGINAL_COMMAND="$SSH_ORIGINAL_COMMAND" \
+REPOSITORY="$RECEIVE_REPO" \
+USERNAME="$RECEIVE_USER" \
+FINGERPRINT="$RECEIVE_FINGERPRINT" \
+POD_NAMESPACE="$POD_NAMESPACE" \
+boot git-receive | strip_remote_prefix
 `
 
 var preReceiveHookTpl = template.Must(template.New("hooks").Parse(preReceiveHookTplStr))

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -31,16 +31,7 @@ strip_remote_prefix() {
     stdbuf -i0 -o0 -e0 sed "s/^/"$'\e[1G'"/"
 }
 
-GIT_HOME={{.GitHome}} \
-SSH_CONNECTION="$SSH_CONNECTION" \
-SSH_ORIGINAL_COMMAND="$SSH_ORIGINAL_COMMAND" \
-REPOSITORY="$RECEIVE_REPO" \
-USERNAME="$RECEIVE_USER" \
-FINGERPRINT="$RECEIVE_FINGERPRINT" \
-POD_NAMESPACE="$POD_NAMESPACE" \
-SLUG_BUILDER_IMAGE_PULL_POLICY="$SLUG_BUILDER_IMAGE_PULL_POLICY" \
-DOCKER_BUILDER_IMAGE_PULL_POLICY="$DOCKER_BUILDER_IMAGE_PULL_POLICY" \
-boot git-receive | strip_remote_prefix
+GIT_HOME={{.GitHome}} boot git-receive | strip_remote_prefix
 `
 
 var preReceiveHookTpl = template.Must(template.New("hooks").Parse(preReceiveHookTplStr))


### PR DESCRIPTION
# Summary of Changes

This PR removes the environment variable declarations from the git pre-receive hook script. When any one of the environment variables is not set in the main process, it's sent into the pre-receive hook process as the empty string, and that was leading to configuration errors in the hook, which was failing builds.

For example, if `SLUG_BUILDER_IMAGE_PULL_POLICY` was empty in the main process, it would be sent to `""` in the hook before this change. Then, the hook would try to convert `""` to a valid pull policy, which would fail, and the entire build would fail.

# Issue(s) that this PR Closes

Fixes #293

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

None

# Associated [Documentation](https://github.com/deis/docs-v2) PR(s)

None

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

None

# Testing Instructions

1. Start a builder with no `SLUG_BUILDER_IMAGE_PULL_POLICY` or `DOCKER_BUILDER_IMAGE_PULL_POLICY` image pull policy environment variables set
2. Do a `git push` with a buildpack app
3. Do a `git push` with a dockerfile app

The result of both steps 2 and 3 should be a successful build, and in both cases, the appropriate image (slugbuilder and dockerbuilder, respectively) should be pulled in all cases (i.e. with `imagePullPolicy: Always`)

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)