### PR TITLE
fix(bug): use the deis time which supports RFC3339 dates

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 28588ab7ed3ab5c729ab93c672124f10b14abb064d0579a885d12dece5476d44
-updated: 2016-03-25T13:36:22.639496896-06:00
+hash: e4e94613a0041e98bda9501d42a1c620551794fd9e70759766149101a0dc701c
+updated: 2016-04-18T16:26:01.119187285-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -52,7 +52,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/pkg
-  version: b8679a4d7fe2fe0393c66c620eff7df86c9f7982
+  version: 7f41ea6de942139d5de67f4d4cb2cccced991f6f
   subpackages:
   - time
   - log

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,7 +22,7 @@ import:
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - package: github.com/pborman/uuid
 - package: github.com/deis/pkg
-  version: b8679a4d7fe2fe0393c66c620eff7df86c9f7982
+  version: 7f41ea6de942139d5de67f4d4cb2cccced991f6f
   subpackages:
   - time
   - log


### PR DESCRIPTION
# Summary of Changes

use the latest deis/pkg/time which supports RFC3339

# Issue(s) that this PR Closes

git push in builder is currently broken because of https://github.com/deis/controller/pull/637

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

1. Create a Deis Cluster
2. deploy an app using git push deis master
3. app should be deployed properly and running

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)