### PR TITLE
feat(pkg/sshd): Store private keys in kubernetes secret

### DIFF
--- a/pkg/routes.go
+++ b/pkg/routes.go
@@ -20,11 +20,7 @@ func routes(reg *cookoo.Registry) {
 		Help: "Boot the builder",
 		Does: []cookoo.Task{
 
-			// SSHD: Create and configure host keys.
-			cookoo.Cmd{
-				Name: "installSshHostKeys",
-				Fn:   sshd.GenSSHKeys,
-			},
+			// SSHD: Configure host keys.
 			cookoo.Cmd{
 				Name: sshd.HostKeys,
 				Fn:   sshd.ParseHostKeys,

--- a/pkg/sshd/sshd.go
+++ b/pkg/sshd/sshd.go
@@ -3,7 +3,6 @@ package sshd
 import (
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 
 	"golang.org/x/crypto/ssh"
 
@@ -103,16 +102,4 @@ func Configure(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrup
 	}
 
 	return cfg, nil
-}
-
-// GenSSHKeys generates the default set of SSH host keys.
-func GenSSHKeys(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
-	log.Debugf(c, "Generating ssh keys for sshd")
-	// Generate a new key
-	out, err := exec.Command("ssh-keygen", "-A").CombinedOutput()
-	if err != nil {
-		log.Infof(c, "ssh-keygen: %s", out)
-		return nil, err
-	}
-	return nil, nil
 }

--- a/pkg/sshd/sshd.go
+++ b/pkg/sshd/sshd.go
@@ -45,17 +45,6 @@ func ParseHostKeys(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Inte
 			}
 		}
 	}
-	if c.Get("enableV1", false).(bool) {
-		path := "/etc/ssh/ssh_host_key"
-		if key, err := ioutil.ReadFile(path); err != nil {
-			log.Errf(c, "Failed to read ssh_host_key")
-		} else if hk, err := ssh.ParsePrivateKey(key); err == nil {
-			log.Infof(c, "Parsed host key %s.", path)
-			hostKeys = append(hostKeys, hk)
-		} else {
-			log.Errf(c, "Failed to parse host key %s: %s", path, err)
-		}
-	}
 	return hostKeys, nil
 }
 

--- a/pkg/sshd/sshd.go
+++ b/pkg/sshd/sshd.go
@@ -31,7 +31,7 @@ const (
 func ParseHostKeys(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
 	log.Debugf(c, "Parsing ssh host keys")
 	hostKeyTypes := p.Get("keytypes", []string{"rsa", "dsa", "ecdsa"}).([]string)
-	pathTpl := p.Get("path", "/etc/ssh/ssh_host_%s_key").(string)
+	pathTpl := p.Get("path", "/var/run/secrets/deis/builder/ssh/ssh-host-%s-key").(string)
 	hostKeys := make([]ssh.Signer, 0, len(hostKeyTypes))
 	for _, t := range hostKeyTypes {
 		path := fmt.Sprintf(pathTpl, t)

--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -1,8 +1,8 @@
 Port 2223
 Protocol 2
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /var/run/secrets/deis/builder/ssh/ssh-host-rsa-key
+HostKey /var/run/secrets/deis/builder/ssh/ssh-host-dsa-key
+HostKey /var/run/secrets/deis/builder/ssh/ssh-host-ecdsa-key
 UsePrivilegeSeparation yes
 KeyRegenerationInterval 3600
 ServerKeyBits 768


### PR DESCRIPTION
# Summary of Changes

This PR moves the SSH private keys into a kubernetes secret such that when the builder is restarted (or destroyed), it retains the same private keys for authenticating clients.

Since the host keys are supplied by kubernetes, we no longer need to generate the host keys, so that code has also been removed.

# Issue(s) that this PR Closes

Closes #157 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

No changes required. The existing end-to-end tests ensure that the user can deploy applications to Workflow given this change. However, end-to-end won't work until deis/charts#237 is merged.

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

No changes required.

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

No design document required.

# Testing Instructions

1. Create a Deis Cluster using the chart changes in deis/charts#237
2. Deploy a buildpack app (example-go)
3. Destroy the builder with `kubectl --namespace=deis destroy pod deis-builder-xxxx`
4. Deploy a second buildpack app

Originally, you would see a warning that "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!" and to check `~/.ssh/known_hosts`, but now it should pass without a warning.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)
