### PR TITLE
fix(slugbuilder): check for the succeded status while waiting for slugbuilder pod

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -170,10 +170,13 @@ func addEnvToPod(pod api.Pod, key, value string) {
 	}
 }
 
-// waitForPod waits for a pod in state running or failed
+// waitForPod waits for a pod in state running, succeeded or failed
 func waitForPod(c *client.Client, ns, podName string, ticker, interval, timeout time.Duration) error {
 	condition := func(pod *api.Pod) (bool, error) {
 		if pod.Status.Phase == api.PodRunning {
+			return true, nil
+		}
+		if pod.Status.Phase == api.PodSucceeded {
 			return true, nil
 		}
 		if pod.Status.Phase == api.PodFailed {


### PR DESCRIPTION
# Summary of Changes
Since the only reason we need to check if the pod is started or not is to stream the logs, we can add a check to see pod completed status if the pod run has completed before we started checking. 
# Issue(s) that this PR Closes
Closes #199 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. deploy an app
3. you should be able to successfully deploy and should not be able to reproduce the scenario mentioned in #298 

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)
