### PR TITLE
ref(Makefile): use go 1.6.2 and compress with upx directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export GO15VENDOREXPERIMENT=1
 
 # dockerized development environment variables
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.1
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 # doesn't allow +, so we use -.
 BINARY_DEST_DIR := rootfs/usr/bin
 # Common flags passed into Go's linker.
-LDFLAGS := "-s -X main.version=${VERSION}"
+LDFLAGS := "-s -w -X main.version=${VERSION}"
 # Docker Root FS
 BINDIR := ./rootfs
 
@@ -35,9 +35,9 @@ glideup:
 # the Docker environment. Other alternatives are cross-compiling, doing
 # the build as a `docker build`.
 build:
-	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags ${LDFLAGS} -o ${BINARY_DEST_DIR}/boot boot.go || exit 1
+	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags ${LDFLAGS} -o ${BINARY_DEST_DIR}/boot boot.go
 	@$(call check-static-binary,$(BINARY_DEST_DIR)/boot)
-	${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE} goupx ${BINARY_DEST_DIR}/boot || exit 1
+	${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE} upx -9 ${BINARY_DEST_DIR}/boot
 
 test:
 	${DEV_ENV_CMD} sh -c 'go test $$(glide nv)'


### PR DESCRIPTION
# Summary of Changes

Builds the builder  `boot` binary with go 1.6.2 and compresses it directly with `upx`.  The `goupx` tool isn't needed since go 1.6 [according to its author](https://github.com/pwaller/goupx/blob/master/README.md#update-20160310).

See also https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/ for a discussion of the binary compression strategy Workflow components are also using.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)