### PR TITLE
docs(README): add codecov.io badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rootfs/bin/boot
 vendor/
 rootfs/usr/bin/
 ./builder
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ sudo: required
 install:
   - make bootstrap
 script:
-  - make test build docker-build
+  - make test-cover build docker-build
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export GO15VENDOREXPERIMENT=1
 
 # dockerized development environment variables
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.12.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
@@ -40,6 +40,9 @@ build:
 
 test:
 	${DEV_ENV_CMD} sh -c 'go test $$(glide nv)'
+
+test-cover:
+	${DEV_ENV_CMD} test-cover.sh
 
 update-changelog:
 	${DEV_ENV_PREFIX} -e RELEASE=${WORKFLOW_RELEASE} ${DEV_ENV_IMAGE} gen-changelog.sh \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Deis Builder v2
 
-[![Build Status](https://travis-ci.org/deis/builder.svg?branch=master)](https://travis-ci.org/deis/builder)
-[![Go Report Card](https://goreportcard.com/badge/github.com/deis/builder)](https://goreportcard.com/report/github.com/deis/builder)
-[![codebeat badge](https://codebeat.co/badges/e29e5e2b-531d-4374-810b-f05053c47688)](https://codebeat.co/projects/github-com-deis-builder) [![Docker Repository on Quay](https://quay.io/repository/deisci/builder/status "Docker Repository on Quay")](https://quay.io/repository/deisci/builder)
+[![Build Status](https://travis-ci.org/deis/builder.svg?branch=master)](https://travis-ci.org/deis/builder) [![codecov.io](https://codecov.io/github/deis/bulder/coverage.svg?branch=master)](https://codecov.io/github/deis/builder?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/deis/builder)](https://goreportcard.com/report/github.com/deis/builder)[![codebeat badge](https://codebeat.co/badges/e29e5e2b-531d-4374-810b-f05053c47688)](https://codebeat.co/projects/github-com-deis-builder) [![Docker Repository on Quay](https://quay.io/repository/deisci/builder/status "Docker Repository on Quay")](https://quay.io/repository/deisci/builder)
 
 Deis (pronounced DAY-iss) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster, making it easy to deploy and manage applications on your own servers.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+  slug: "deis/builder"


### PR DESCRIPTION
# Summary of Changes

`make test-cover` runs the go unit tests while accumulating a `coverage.txt` file suitable for shipping to https://codecov.io/. This also adds a badge to README.md: [![codecov.io](https://codecov.io/github/deis/builder/coverage.svg?branch=master)](https://codecov.io/github/deis/builder?branch=master)

```console
$ make test-cover
docker run --rm -e GO15VENDOREXPERIMENT=1 -v /Users/matt/Projects/src/github.com/deis/builder:/go/src/github.com/deis/builder -w /go/src/github.com/deis/builder quay.io/deis/go-dev:latest test-cover.sh
?   	github.com/deis/builder/pkg	[no test files]
ok  	github.com/deis/builder/pkg/cleaner	5.017s	coverage: 84.6% of statements
?   	github.com/deis/builder/pkg/conf	[no test files]
ok  	github.com/deis/builder/pkg/controller	0.020s	coverage: 27.3% of statements
ok  	github.com/deis/builder/pkg/env	0.009s	coverage: 100.0% of statements
ok  	github.com/deis/builder/pkg/git	0.024s	coverage: 4.9% of statements
ok  	github.com/deis/builder/pkg/gitreceive	0.078s	coverage: 20.4% of statements
ok  	github.com/deis/builder/pkg/healthsrv	0.027s	coverage: 85.5% of statements
?   	github.com/deis/builder/pkg/k8s	[no test files]
ok  	github.com/deis/builder/pkg/sshd	1.699s	coverage: 65.6% of statements
ok  	github.com/deis/builder/pkg/storage	0.016s	coverage: 51.6% of statements
?   	github.com/deis/builder/pkg/sys	[no test files]
?   	github.com/deis/builder	[no test files]
$ ls -alh coverage.txt 
-rw-r--r--  1 matt  staff    28K Apr 24 12:31 coverage.txt
$ head coverage.txt 

mode: atomic
github.com/deis/builder/pkg/cleaner/cleaner.go:23.74,25.16 2 1
github.com/deis/builder/pkg/cleaner/cleaner.go:28.2,28.6 1 1
github.com/deis/builder/pkg/cleaner/cleaner.go:25.16,27.3 1 0
github.com/deis/builder/pkg/cleaner/cleaner.go:28.6,29.10 1 87915699
github.com/deis/builder/pkg/cleaner/cleaner.go:30.3,31.11 1 87916906
github.com/deis/builder/pkg/cleaner/cleaner.go:34.4,34.31 1 7
github.com/deis/builder/pkg/cleaner/cleaner.go:31.11,32.10 1 87918462
github.com/deis/builder/pkg/cleaner/cleaner.go:34.31,35.32 1 3
...
```

TODO:

- [X] Integrate with codecov.io and verify GitHub coverage comments are published

# Issue(s) that this PR Requires

deis/docker-go-dev#34

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. ~~Build a local `deis/go-dev:latest` image from the PR referenced above~~
2. Check out this PR and run `make test-cover`

Anticipated results:

1. There is a `coverage.txt` file present containing code analysis data
2. The coverage.txt file is not in version control or marked as needing to be added

Next steps:

1. ~~Help me figure out how to upload `coverage.txt` to codecov.io~~
2. Make a bunch of PRs just like this until all deis/* Go projects have code coverage reporting :boom:

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits are squashed into logical units of work
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

