### PR TITLE
ref(k8s_util): change debugKey to DEIS_DEBUG

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -17,7 +17,7 @@ const (
 
 	tarPath          = "TAR_PATH"
 	putPath          = "PUT_PATH"
-	debugKey         = "DEBUG"
+	debugKey         = "DEIS_DEBUG"
 	objectStore      = "objectstorage-keyfile"
 	dockerSocketName = "docker-socket"
 	dockerSocketPath = "/var/run/docker.sock"


### PR DESCRIPTION
# Summary of Changes

This environment variable is being introduced into the actual application build. causing libraries
like the ruby gem `hiredis` to install differently because we are affecting the build environment.

# Issue(s) that this PR Closes

Please list the issue(s) that this PR closes, similar to the below:

closes deis/workflow#178

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster with this change as well as deis/slugbuilder#70
2. Deploy https://github.com/matthewrudy/ruby-env.git

The app should be deployed. Before, it should fail if using a version of `hiredis` earlier than https://github.com/redis/hiredis/pull/418, which is what matthewrudy/ruby-env demonstrates.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)