### PR TITLE
feat(controller):Show the error message from controller instead of response code

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -31,6 +31,11 @@ type BuildHookResponse struct {
 	Release map[string]int `json:"release"`
 }
 
+// ControllerErrorResponse represents a controller's error response object.
+type ControllerErrorResponse struct {
+	ErrorMsg string `json:"detail"`
+}
+
 // Config represents a Deis application's configuration.
 type Config struct {
 	Owner   string                 `json:"owner"`


### PR DESCRIPTION
# Summary of Changes

Show the error message returned from the controller instead of the response code

# Issue(s) that this PR Closes

Closes #323 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Deploy a docker app without exposing any port and proc file so that the controller will raise an exception and the build fails.
3. Builder should output the error message instead of the response code

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits are squashed into logical units of work
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)