### PR TITLE
ref(k8s): update k8s api to 1.2.4

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b1efd8d89a7114d3646633cc78039ee057892a519f24d037883ef2b890d7c40b
-updated: 2016-05-18T14:01:38.723061304-07:00
+hash: 14f1bdb619e0654cdeb3d1455dffa67ded9b4b09b1b5451c75b4a520bdc18800
+updated: 2016-06-01T16:42:49.464730878-06:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -9,28 +9,28 @@ imports:
   version: 49c3892b61af1d4996292a3025f36e4dfa25eaee
   subpackages:
   - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
   - private/endpoints
   - private/protocol
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
   - private/signer/v4
   - private/waiter
   - service/cloudfront/sign
   - service/s3
-  - aws/awserr
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/ec2metadata
-  - aws/request
-  - aws/session
-  - aws/client
-  - aws/client/metadata
-  - aws/awsutil
-  - aws/corehandlers
-  - aws/defaults
-  - private/protocol/restxml
-  - private/protocol/query
-  - private/protocol/rest
-  - private/protocol/xml/xmlutil
-  - private/protocol/query/queryutil
 - name: github.com/Azure/azure-sdk-for-go
   version: 95361a2573b1fa92a00c5fc2707a80308483c6f9
   subpackages:
@@ -41,10 +41,6 @@ imports:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
-- name: github.com/bradfitz/http2
-  version: f8202bc903bda493ebba4aa54922d78430c2c42f
-  subpackages:
-  - hpack
 - name: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
 - name: github.com/davecgh/go-spew
@@ -52,13 +48,13 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/pkg
-  version: 7f41ea6de942139d5de67f4d4cb2cccced991f6f
+  version: 189ed6bd6b6aa6629b72c2c5472095e176eec8a6
   subpackages:
   - time
   - log
   - prettyprint
 - name: github.com/docker/distribution
-  version: 193356763efd27a744a0e776d3ce812a74c20673
+  version: 8448fac2cc300df316ee3ab851039892483f235c
   repo: https://github.com/deis/distribution
   vcs: git
   subpackages:
@@ -72,7 +68,7 @@ imports:
   - registry/client/transport
   - uuid
 - name: github.com/docker/docker
-  version: 2b27fe17a1b3fb8472fde96d768fa70996adf201
+  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
   subpackages:
   - pkg/jsonmessage
   - pkg/mount
@@ -81,15 +77,10 @@ imports:
   - pkg/term
   - pkg/timeutils
   - pkg/units
-- name: github.com/docker/libcontainer
-  version: 5dc7ba0f24332273461e45bc49edcb4d5aa6c44c
-  subpackages:
-  - cgroups/fs
-  - configs
-  - cgroups
-  - system
+- name: github.com/docker/go-units
+  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
 - name: github.com/emicklei/go-restful
-  version: 1f9a0ee00ff93717a275e15b30cf7df356255877
+  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
   subpackages:
   - swagger
   - log
@@ -100,11 +91,11 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 0f7a9caded1fb3c9cc5a9b4bcf2ff633cc8ae644
+  version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
   subpackages:
   - proto
 - name: github.com/google/cadvisor
-  version: a8085bf9276c22f16dbcd7aa56f0d4d0626a0b2e
+  version: 546a3771589bdb356777c646c6eca24914fdd48b
   subpackages:
   - api
   - cache/memory
@@ -133,13 +124,21 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/juju/ratelimit
-  version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: cea086319492c3940683ea5e122aa5de70a33923
+  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/opencontainers/runc
+  version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
+  subpackages:
+  - libcontainer
+  - libcontainer/cgroups/fs
+  - libcontainer/configs
+  - libcontainer/cgroups
+  - libcontainer/system
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/prometheus/client_golang
@@ -159,10 +158,16 @@ imports:
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/Sirupsen/logrus
   version: 55eb11d21d2a31a3cc93838241d04800f52e823d
+  subpackages:
+  - formatters/logstash
 - name: github.com/spf13/pflag
   version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
   repo: https://github.com/spf13/pflag
   vcs: git
+- name: github.com/ugorji/go
+  version: f4485b318aadd133842532f841dc205a8e339d74
+  subpackages:
+  - codec
 - name: golang.org/x/crypto
   version: f7445b17d61953e333441674c2d11e91ae4559d3
   subpackages:
@@ -172,15 +177,17 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
+  - http2
   - trace
+  - http2/hpack
   - internal/timeseries
 - name: golang.org/x/oauth2
-  version: 8914e5017ca260f2a3a1575b1e6868874050d95e
+  version: 045497edb6234273d67dbc25da3f2ddbc4c4cacf
   subpackages:
   - google
-  - jwt
   - internal
   - jws
+  - jwt
 - name: google.golang.org/api
   version: fceeaa645c4015c833842e6ed6052b2dda667079
   repo: https://code.googlesource.com/google-api-go-client
@@ -193,34 +200,37 @@ imports:
 - name: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/app_identity
-  - internal/modules
   - internal/base
   - internal/datastore
   - internal/log
+  - internal/modules
   - internal/remote_api
+  - urlfetch
+  - internal/urlfetch
 - name: google.golang.org/cloud
-  version: 2400193c85c3561d13880d34e0e10c4315bb02af
+  version: 975617b05ea8a58727e6c1a06b6161ff4185a9f2
   subpackages:
-  - storage
   - compute/metadata
   - internal
   - internal/opts
+  - storage
 - name: google.golang.org/grpc
-  version: 91c8b79535eb6045d70ec671d302213f88a3ab95
+  version: d3ddb4469d5a1b949fc7a7da7c1d6a0d1b6de994
   subpackages:
   - codes
   - credentials
   - grpclog
+  - internal
   - metadata
+  - naming
+  - peer
   - transport
 - name: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - name: k8s.io/kubernetes
-  version: 596055084fbaef446983b14097f832f60ae57634
+  version: 3eed1e3be6848b877ff80a93da3785d9034d0a4f
   subpackages:
   - pkg/client/unversioned
   - pkg/api
@@ -230,34 +240,68 @@ imports:
   - pkg/util/wait
   - pkg/watch
   - pkg/api/install
-  - pkg/api/latest
   - pkg/api/meta
   - pkg/api/unversioned
-  - pkg/api/validation
+  - pkg/apimachinery/registered
+  - pkg/apis/authorization/install
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/componentconfig/install
   - pkg/apis/extensions
   - pkg/apis/extensions/install
-  - pkg/client/metrics
-  - pkg/conversion/queryparams
+  - pkg/apis/metrics/install
+  - pkg/client/restclient
+  - pkg/client/typed/discovery
   - pkg/runtime
-  - pkg/util
+  - pkg/util/net
   - pkg/util/sets
   - pkg/version
-  - pkg/watch/json
   - pkg/api/resource
   - pkg/auth/user
   - pkg/conversion
+  - pkg/runtime/serializer
   - pkg/types
+  - pkg/util
+  - pkg/util/intstr
   - pkg/util/rand
-  - pkg/util/fielderrors
   - pkg/util/validation
-  - pkg/util/errors
-  - pkg/api/registered
-  - pkg/api/util
+  - pkg/util/validation/field
+  - pkg/util/runtime
   - pkg/api/v1
+  - pkg/apimachinery
+  - pkg/util/errors
+  - pkg/apis/authorization
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/batch/v1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/metrics
+  - pkg/apis/metrics/v1alpha1
+  - pkg/api/validation
+  - pkg/client/metrics
+  - pkg/client/transport
+  - pkg/watch/json
+  - pkg/conversion/queryparams
+  - third_party/forked/reflect
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/versioning
+  - pkg/util/integer
+  - pkg/util/parsers
+  - pkg/kubelet/qos
+  - pkg/master/ports
+  - pkg/api/endpoints
+  - pkg/api/pod
+  - pkg/api/service
+  - pkg/api/util
   - pkg/capabilities
   - pkg/util/yaml
-  - pkg/apis/extensions/v1beta1
-  - third_party/forked/reflect
+  - pkg/util/hash
+  - pkg/util/net/sets
 - name: speter.net/go/exp/math/dec/inf
   version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
   repo: https://github.com/belua/inf

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,14 +16,14 @@ import:
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - package: github.com/pborman/uuid
 - package: github.com/deis/pkg
-  version: 7f41ea6de942139d5de67f4d4cb2cccced991f6f
+  version: 189ed6bd6b6aa6629b72c2c5472095e176eec8a6
   subpackages:
   - time
   - log
 - package: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
 - package: k8s.io/kubernetes
-  version: ~1.1
+  version: 1.2.4
 - package: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
 - package: github.com/docker/distribution

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -84,7 +84,7 @@ func dirHasGitSuffix(dir string) bool {
 // On any error, it uses log messages to output a human readable description of what happened.
 func Run(gitHome string, nsLister k8s.NamespaceLister, fs sys.FS, pollSleepDuration time.Duration) error {
 	for {
-		nsList, err := nsLister.List(labels.Everything(), fields.Everything())
+		nsList, err := nsLister.List(api.ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything()})
 		if err != nil {
 			log.Printf("Cleaner error listing namespaces (%s)", err)
 			continue

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -190,7 +190,7 @@ func build(
 	req := kubeClient.Get().Namespace(newPod.Namespace).Name(newPod.Name).Resource("pods").SubResource("log").VersionedParams(
 		&api.PodLogOptions{
 			Follow: true,
-		}, api.Scheme)
+		}, api.ParameterCodec)
 
 	rc, err := req.Stream()
 	if err != nil {

--- a/pkg/healthsrv/namespace_lister.go
+++ b/pkg/healthsrv/namespace_lister.go
@@ -11,12 +11,12 @@ import (
 // for unit tests.
 type NamespaceLister interface {
 	// List lists all namespaces that are selected by the given label and field selectors.
-	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
+	List(opts api.ListOptions) (*api.NamespaceList, error)
 }
 
 type emptyNamespaceLister struct{}
 
-func (n emptyNamespaceLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
+func (n emptyNamespaceLister) List(opts api.ListOptions) (*api.NamespaceList, error) {
 	return &api.NamespaceList{}, nil
 }
 
@@ -24,7 +24,7 @@ type errNamespaceLister struct {
 	err error
 }
 
-func (e errNamespaceLister) List(labels.Selector, fields.Selector) (*api.NamespaceList, error) {
+func (e errNamespaceLister) List(opts api.ListOptions) (*api.NamespaceList, error) {
 	return nil, e.err
 }
 
@@ -35,7 +35,7 @@ func (e errNamespaceLister) List(labels.Selector, fields.Selector) (*api.Namespa
 // errCh. At most one of {succCh, errCh} will be sent on. If stopCh is closed, no pending or
 // future sends will occur.
 func listNamespaces(nl NamespaceLister, succCh chan<- *api.NamespaceList, errCh chan<- error, stopCh <-chan struct{}) {
-	nsList, err := nl.List(labels.Everything(), fields.Everything())
+	nsList, err := nl.List(api.ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything()})
 	if err != nil {
 		select {
 		case errCh <- err:

--- a/pkg/k8s/namespace.go
+++ b/pkg/k8s/namespace.go
@@ -2,9 +2,6 @@ package k8s
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/watch"
 )
 
 // NamespaceLister is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
@@ -17,18 +14,5 @@ import (
 //	var nsl NamespaceLister
 //	nsl = kubeClient.Namespaces()
 type NamespaceLister interface {
-	List(labels.Selector, fields.Selector) (*api.NamespaceList, error)
-}
-
-// NamespaceWatcher is a (k8s.io/kubernetes/pkg/client/unversioned).NamespaceInterface compatible
-// interface which only has the Watch function. It's used in places that only need perform watches,
-// to make those codebases easier to test and more easily swappable with other implementations
-// (should the need arise).
-//
-// Example usage:
-//
-//	var nsl NamespaceWatcher
-//	nsl = kubeClient.Namespaces()
-type NamespaceWatcher interface {
-	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	List(opts api.ListOptions) (*api.NamespaceList, error)
 }

--- a/pkg/k8s/watch.go
+++ b/pkg/k8s/watch.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+var (
+	resyncPeriod = 30 * time.Second
+)
+
+//PodWatcher is a struct which holds the return values of (k8s.io/kubernetes/pkg/controller/framework).NewIndexerInformer together.
+type PodWatcher struct {
+	Store      cache.StoreToPodLister
+	Controller *framework.Controller
+}
+
+//NewPodWatcher creates a new BuildPodWatcher useful to list the pods using a cache which gets updated based on the watch func.
+func NewPodWatcher(c *client.Client, ns string) *PodWatcher {
+	pw := &PodWatcher{}
+
+	pw.Store.Store, pw.Controller = framework.NewIndexerInformer(
+		&cache.ListWatch{
+			ListFunc:  podListFunc(c, ns),
+			WatchFunc: podWatchFunc(c, ns),
+		},
+		&api.Pod{},
+		resyncPeriod,
+		framework.ResourceEventHandlerFuncs{},
+		cache.Indexers{},
+	)
+
+	return pw
+}
+
+func podListFunc(c *client.Client, ns string) func(options api.ListOptions) (runtime.Object, error) {
+	return func(opts api.ListOptions) (runtime.Object, error) {
+		return c.Pods(ns).List(api.ListOptions{
+			LabelSelector: labels.Everything(),
+		})
+	}
+}
+
+func podWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+	return func(opts api.ListOptions) (watch.Interface, error) {
+		return c.Pods(ns).Watch(api.ListOptions{
+			LabelSelector: labels.Everything(),
+		})
+	}
+}


### PR DESCRIPTION
# Summary of Changes

change the k8s api version to 1.2.4 and fix the wait for pod as k8s now logs throttling requests.

# Issue(s) that this PR Closes

Please list the issue(s) that this PR closes, similar to the below:

Closes #343 
Closes #344 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. deploy an app with different storage backends
3. app should be deployed without any error

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)
