### PR TITLE
docs(pkg): update help URL to https://deis.com/

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -259,7 +259,7 @@ func build(
 
 	log.Info("Done, %s:v%d deployed to Deis\n", appName, release)
 	log.Info("Use 'deis open' to view this application in your browser\n")
-	log.Info("To learn more, use 'deis help' or visit http://deis.io\n")
+	log.Info("To learn more, use 'deis help' or visit https://deis.com/\n")
 
 	run(repoCmd(repoDir, "git", "gc"))
 


### PR DESCRIPTION
# Summary of Changes

Updates the URL printed after a successful `git push` to https://deis.com/ instead of http://docs.deis.io/.

# Issue(s) that this PR References

See deis/example-clojure-ring#5.

# Testing Instructions

The output of a successful `git push` for an app should reference the above URL, not anything at deis.io.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

