### PR TITLE
fix(sshd): unlock the repository when gitreceive succeeds or fails

### DIFF
--- a/pkg/sshd/lock.go
+++ b/pkg/sshd/lock.go
@@ -38,9 +38,9 @@ func wrapInLock(lck RepositoryLock, repoName string, fn func() error) error {
 		case <-doneCh:
 		}
 	}()
+	defer lck.Unlock(repoName)
 	select {
 	case <-timer.C:
-		lck.Unlock(repoName)
 		defer close(doneCh)
 		return fmt.Errorf("%s lock exceeded timout", repoName)
 	case err := <-fnCh:

--- a/pkg/sshd/lock_test.go
+++ b/pkg/sshd/lock_test.go
@@ -1,6 +1,7 @@
 package sshd
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,10 @@ import (
 
 const (
 	callbackTimeout = 1 * time.Second
+)
+
+var (
+	gitError = errors.New("git receive error")
 )
 
 func TestMultipleSameRepoLocks(t *testing.T) {
@@ -91,7 +96,10 @@ func TestWrapInLock(t *testing.T) {
 	assert.NoErr(t, wrapInLock(lck, "repo", func() error {
 		return nil
 	}))
-	lck.Lock("repo")
+	assert.Err(t, gitError, wrapInLock(lck, "repo", func() error {
+		return gitError
+	}))
+	assert.NoErr(t, lck.Lock("repo"))
 	assert.Err(t, errAlreadyLocked, wrapInLock(lck, "repo", func() error {
 		return nil
 	}))


### PR DESCRIPTION
# Summary of Changes

Currently the builder is not unlocking the repo if the git push succeeds or fails because of which we can't do multiple releases to any app

# Issue(s) that this PR Closes

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster
2. Register an app
3. do git push again or do a new release and you should succeed.

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

