### PR TITLE
fix(server.go): don't reply false if lock fails

### DIFF
--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -255,7 +255,6 @@ func (s *server) answer(channel ssh.Channel, requests <-chan *ssh.Request, conda
 						log.Err("Failed to write to channel: %s", err)
 					}
 					sendExitStatus(1, channel)
-					req.Reply(false, nil)
 					return nil
 				}
 


### PR DESCRIPTION
# Summary of Changes

Removes an uneeded `req.Reply` call that confused builder output during a simultaneous `git push` operation. This change was suggested by @kmala. :metal: 

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

We will work on capturing this behavior in an e2e test next, but it is not required to merge this. See also deis/workflow-e2e#230.

# Testing Instructions

1. Create a Deis Cluster
2. Register an app
3. `git push` the app but hit Ctrl+C to interrupt `git` while it is pushing
4. Retry the `git push` operation repeatedly and observe the results

What you should see:
```
$ git push deis master
Counting objects: 96, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (74/74), done.
Writing objects: 100% (96/96), 20.84 KiB | 0 bytes/s, done.
Total 96 (delta 40), reused 45 (delta 17)
^CKilled by signal 2.

$ git push deis master
fatal: remote error: Another git push is ongoing
$ git push deis master
fatal: remote error: Another git push is ongoing
$ git push deis master
fatal: remote error: Another git push is ongoing
$ echo $?
128
$ git push deis master
fatal: remote error: Another git push is ongoing
$ git push deis master
fatal: remote error: Another git push is ongoing
$ git push deis master
Everything up-to-date
$ echo $?
0
```

What you should *no longer* see (refs #365):
```
$ git push deis master
Counting objects: 96, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (74/74), done.
Writing objects: 100% (96/96), 20.84 KiB | 0 bytes/s, done.
Total 96 (delta 40), reused 45 (delta 17)
Starting build... but first, coffee!
^CKilled by signal 2.

$ git push deis master
exec request failed on channel 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
$ git push deis master
exec request failed on channel 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
$ git push deis master
exec request failed on channel 0
fatal: remote error: Another git push is ongoing
$ git push deis master
exec request failed on channel 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

