### PR TITLE
fix(pkg): set check timeouts to 10s

### DIFF
--- a/pkg/healthsrv/healthz_handler.go
+++ b/pkg/healthsrv/healthz_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	waitTimeout = 2 * time.Second
+	waitTimeout = 10 * time.Second
 )
 
 func healthZHandler(bLister BucketLister, serverCircuit *sshd.Circuit) http.Handler {


### PR DESCRIPTION
# Summary of Changes

Changes the healthcheck/readiness check internal timeout value to 10 seconds, to match the values used in the [Workflow charts](https://github.com/deis/charts/blob/master/workflow-dev/tpl/deis-controller-rc.yaml#L34).

# Issue(s) that this PR Closes

This is one change of several that seem to ameliorate readiness check misbehavior under load. It doesn't fix the situation on its own but does seem to help.

Refs deis/workflow-e2e#215.

# Pull Request Hygiene TODOs

- [X] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [X] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

