### PR TITLE
fix(pkg/conf): skip ..data symlink reading creds

### DIFF
--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -51,7 +51,7 @@ func GetStorageParams(env sys.Env) (Parameters, error) {
 	}
 
 	for _, file := range files {
-		if file.IsDir() {
+		if file.IsDir() || file.Name() == "..data" {
 			continue
 		}
 		data, err := ioutil.ReadFile(storageCredLocation + file.Name())

--- a/pkg/conf/config_test.go
+++ b/pkg/conf/config_test.go
@@ -33,7 +33,7 @@ func TestGetStorageParams(t *testing.T) {
 
 	params, err := GetStorageParams(sys.NewFakeEnv())
 	if err != nil {
-		t.Errorf("recevied error while retrieving storage params: %v", err)
+		t.Errorf("received error while retrieving storage params: %v", err)
 	}
 
 	val, ok := params["foo"]
@@ -51,6 +51,16 @@ func TestGetStorageParams(t *testing.T) {
 
 	_, err = GetStorageParams(sys.NewFakeEnv())
 	if err != nil {
-		t.Errorf("recevied error while retrieving storage params: %v", err)
+		t.Errorf("received error while retrieving storage params: %v", err)
+	}
+
+	// create the special "..data" directory symlink, expecting it to pass
+	if err := os.Symlink(storageCredLocation+"bar", storageCredLocation+"..data"); err != nil {
+		t.Fatalf("could not create dir symlink ..data -> %s: %v", storageCredLocation+"bar", err)
+	}
+
+	_, err = GetStorageParams(sys.NewFakeEnv())
+	if err != nil {
+		t.Errorf("received error while retrieving storage params: %v", err)
 	}
 }


### PR DESCRIPTION
# Summary of Changes

This fixes the remaining problems described in #379 mentioned by @jackfrancis where the deis-builder pod enters a CrashLoop with the following error:

```
Error getting storage parameters (read /var/run/secrets/deis/objectstore/creds/..data: is a directory)`
```

The creds directory structure might look like this (at least on k8s 1.3.0):

```
drwxrwxrwt. 3 root root  200 Jul  9 14:49 .
drwxr-xr-x. 3 root root 4.0K Jul  9 14:50 ..
drwxr-xr-x. 2 root root  160 Jul  9 14:49 ..7987_09_07_14_49_31.664629063
lrwxrwxrwx. 1 root root   31 Jul  9 14:49 ..data -> ..7987_09_07_14_49_31.664629063
lrwxrwxrwx. 1 root root   16 Jul  9 14:49 accesskey -> ..data/accesskey
lrwxrwxrwx. 1 root root   21 Jul  9 14:49 builder-bucket -> ..data/builder-bucket
lrwxrwxrwx. 1 root root   22 Jul  9 14:49 database-bucket -> ..data/database-bucket
lrwxrwxrwx. 1 root root   13 Jul  9 14:49 region -> ..data/region
lrwxrwxrwx. 1 root root   22 Jul  9 14:49 registry-bucket -> ..data/registry-bucket
lrwxrwxrwx. 1 root root   16 Jul  9 14:49 secretkey -> ..data/secretkey
```

The problem is that the credential reading code choked on the dir `..7987_09_07_14_49_31.664629063` which was fixed by @bacongobbler in PR #382.

This second fix also skips the `..data` symlink, which points to a directory but is a symlink, so `IsDir()` returns false.

A more generic solution to this fix would be to check for a symlink, use `Readlink()` and then check for a directory, maybe even recursive. Unless kubernetes adds another level of indirection to the credentials structure, I think that's overkill.

# Issue(s) that this PR Closes

Closes #379

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster on kubernetes 1.3.0
2. Edit the deis-builder rc to point to a deis/builder image with this fix
3. Delete all existing pods belonging to the deis-builder rc
2. Check if the replacement deis-builder pods come up with status running

There is a fixed build in [quay.io/felixbuenemann/builder:git-49085c0](https://quay.io/repository/felixbuenemann/builder) which can be used for quick testing.
