### PR TITLE
feat(registry): use registry proxy to talk to the internal registry

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -149,6 +149,7 @@ func build(
 			slugName,
 			conf.StorageType,
 			conf.DockerBuilderImage,
+			conf.RegistryProxyPort,
 			dockerBuilderImagePullPolicy,
 		)
 	} else {

--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -14,10 +14,10 @@ const (
 // builder's git-receive hook.
 type Config struct {
 	// k8s service discovery env vars
-	ControllerHost string `envconfig:"DEIS_CONTROLLER_SERVICE_HOST" required:"true"`
-	ControllerPort string `envconfig:"DEIS_CONTROLLER_SERVICE_PORT" required:"true"`
-	RegistryHost   string `envconfig:"DEIS_REGISTRY_SERVICE_HOST" required:"true"`
-	RegistryPort   string `envconfig:"DEIS_REGISTRY_SERVICE_PORT" required:"true"`
+	ControllerHost    string `envconfig:"DEIS_CONTROLLER_SERVICE_HOST" required:"true"`
+	ControllerPort    string `envconfig:"DEIS_CONTROLLER_SERVICE_PORT" required:"true"`
+	RegistryHost      string `envconfig:"DEIS_REGISTRY_SERVICE_HOST" required:"true"`
+	RegistryProxyPort string `envconfig:"DEIS_REGISTRY_PROXY_PORT" default:"5555"`
 
 	GitHome                       string `envconfig:"GIT_HOME" required:"true"`
 	SSHConnection                 string `envconfig:"SSH_CONNECTION" required:"true"`

--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -43,7 +43,7 @@ func dockerBuilderPod(
 	tarKey,
 	imageName,
 	storageType,
-	image string,
+	image, registryProxyPort string,
 	pullPolicy api.PullPolicy,
 ) *api.Pod {
 
@@ -55,6 +55,7 @@ func dockerBuilderPod(
 	addEnvToPod(pod, tarPath, tarKey)
 	addEnvToPod(pod, "IMG_NAME", imageName)
 	addEnvToPod(pod, builderStorage, storageType)
+	addEnvToPod(pod, "DEIS_REGISTRY_PROXY_PORT", registryProxyPort)
 
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, api.VolumeMount{
 		Name:      dockerSocketName,

--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -132,6 +132,7 @@ func TestBuildPod(t *testing.T) {
 			build.imgName,
 			build.storageType,
 			build.dockerBuilderImage,
+			"5555",
 			build.dockerBuilderImagePullPolicy,
 		)
 


### PR DESCRIPTION
# Summary of Changes

Pass the registry proxy port to docker builder.
depends this depends on 
https://github.com/deis/controller/pull/866
https://github.com/deis/dockerbuilder/pull/78
https://github.com/deis/charts/pull/305

# Issue(s) that this PR Closes

# Associated [End To End Test](https://github.com/deis/workflow-e2e) PR(s)

# Associated [Documentation](https://github.com/deis/workflow) PR(s)
https://github.com/deis/workflow/pull/370

# Associated [Design Document](http://docs.deis.io/en/latest/contributing/design-documents)(s)

# Testing Instructions

Please provide a detailed list for how to test the changes in this PR.

1. Create a Deis Cluster without insecure regsitry settings
2. Register an dockerfile app
3. the dockerfile app should work fine

# Pull Request Hygiene TODOs

Please make sure the below checklist is complete.

- [x] Your pull request is concise and to the point (make another PR for refactoring nearby code)
- [x] Your commits follow the [commit style guidelines](http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide)

