### PR TITLE
feat(dockerbuilder): expose docker registry authentication credentials to dockerbuilder

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -40,6 +40,7 @@ func dockerBuilderPod(
 	name,
 	namespace string,
 	env map[string]interface{},
+	registry string,
 	tarKey,
 	imageName,
 	storageType,
@@ -56,6 +57,7 @@ func dockerBuilderPod(
 	addEnvToPod(pod, "IMG_NAME", imageName)
 	addEnvToPod(pod, builderStorage, storageType)
 	addEnvToPod(pod, "DEIS_REGISTRY_PROXY_PORT", registryProxyPort)
+	addEnvToPod(pod, "DEIS_REGISTRY_AUTH", registry)
 
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, api.VolumeMount{
 		Name:      dockerSocketName,

--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -40,6 +40,7 @@ type dockerBuildCase struct {
 	name                         string
 	namespace                    string
 	env                          map[string]interface{}
+	registry                     string
 	tarKey                       string
 	imgName                      string
 	dockerBuilderImage           string
@@ -110,16 +111,16 @@ func TestBuildPod(t *testing.T) {
 	}
 
 	dockerBuilds := []dockerBuildCase{
-		{true, "test", "default", emptyEnv, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "img", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "img", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "img", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "img", "customimage", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "img", "customimage", api.PullIfNotPresent, ""},
-		{true, "test", "default", env, "tar", "img", "customimage", api.PullNever, ""},
+		{true, "test", "default", emptyEnv, `{"foo":"bar"}`, "tar", "", "", api.PullAlways, ""},
+		{true, "test", "default", emptyEnv, "{}", "tar", "", "", api.PullAlways, ""},
+		{true, "test", "default", env, "{}", "tar", "", "", api.PullAlways, ""},
+		{true, "test", "default", env, "{}", "tar", "", "", api.PullAlways, ""},
+		{true, "test", "default", emptyEnv, "{}", "tar", "img", "", api.PullAlways, ""},
+		{true, "test", "default", emptyEnv, "{}", "tar", "img", "", api.PullAlways, ""},
+		{true, "test", "default", env, "{}", "tar", "img", "", api.PullAlways, ""},
+		{true, "test", "default", env, "{}", "tar", "img", "customimage", api.PullAlways, ""},
+		{true, "test", "default", env, "{}", "tar", "img", "customimage", api.PullIfNotPresent, ""},
+		{true, "test", "default", env, "{}", "tar", "img", "customimage", api.PullNever, ""},
 	}
 
 	for _, build := range dockerBuilds {
@@ -128,6 +129,7 @@ func TestBuildPod(t *testing.T) {
 			build.name,
 			build.namespace,
 			build.env,
+			build.registry,
 			build.tarKey,
 			build.imgName,
 			build.storageType,

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -38,13 +38,14 @@ type ControllerErrorResponse struct {
 
 // Config represents a Deis application's configuration.
 type Config struct {
-	Owner   string                 `json:"owner"`
-	App     string                 `json:"app"`
-	Values  map[string]interface{} `json:"values"`
-	Memory  map[string]string      `json:"memory"`
-	CPU     map[string]int         `json:"cpu"`
-	Tags    map[string]string      `json:"tags"`
-	UUID    string                 `json:"uuid"`
-	Created time.Time              `json:"created"`
-	Updated time.Time              `json:"updated"`
+	Owner    string                 `json:"owner"`
+	App      string                 `json:"app"`
+	Values   map[string]interface{} `json:"values"`
+	Memory   map[string]string      `json:"memory"`
+	CPU      map[string]int         `json:"cpu"`
+	Tags     map[string]string      `json:"tags"`
+	UUID     string                 `json:"uuid"`
+	Created  time.Time              `json:"created"`
+	Updated  time.Time              `json:"updated"`
+	Registry map[string]interface{} `json:"registry"`
 }


### PR DESCRIPTION
ref #326 

This exposes docker credentials set with `deis registry` as a json environmental variable to dockerbuilder.

I'm working on a PR for dockerbuilder to use this environmental variable to authenticate with docker registries to allow for private base images.