### PR TITLE
fix(k8s_util): proxy registry host/port information to dockerbuilder

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -162,6 +162,8 @@ func build(
 			slugName,
 			conf.StorageType,
 			conf.DockerBuilderImage,
+			conf.RegistryHost,
+			conf.RegistryPort,
 			registryEnv,
 			dockerBuilderImagePullPolicy,
 		)

--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	// k8s service discovery env vars
 	ControllerHost       string `envconfig:"DEIS_CONTROLLER_SERVICE_HOST" required:"true"`
 	ControllerPort       string `envconfig:"DEIS_CONTROLLER_SERVICE_PORT" required:"true"`
+	RegistryHost         string `envconfig:"DEIS_REGISTRY_SERVICE_HOST" required:"true"`
+	RegistryPort         string `envconfig:"DEIS_REGISTRY_SERVICE_PORT" required:"true"`
 	RegistryProxyPort    string `envconfig:"DEIS_REGISTRY_PROXY_PORT" default:"5555"`
 	RegistryLocation     string `envconfig:"DEIS_REGISTRY_LOCATION" default:"on-cluster"`
 	RegistrySecretPrefix string `envconfig:"DEIS_REGISTRY_SECRET_PREFIX" default:"private-registry"`

--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -43,7 +43,9 @@ func dockerBuilderPod(
 	tarKey,
 	imageName,
 	storageType,
-	image string,
+	image,
+	registryHost,
+	registryPort string,
 	registryEnv map[string]string,
 	pullPolicy api.PullPolicy,
 ) *api.Pod {
@@ -56,6 +58,10 @@ func dockerBuilderPod(
 	addEnvToPod(pod, tarPath, tarKey)
 	addEnvToPod(pod, "IMG_NAME", imageName)
 	addEnvToPod(pod, builderStorage, storageType)
+	// inject existing DEIS_REGISTRY_SERVICE_HOST and PORT info to dockerbuilder
+	// see https://github.com/deis/dockerbuilder/issues/83
+	addEnvToPod(pod, "DEIS_REGISTRY_SERVICE_HOST", registryHost)
+	addEnvToPod(pod, "DEIS_REGISTRY_SERVICE_PORT", registryPort)
 
 	for key, value := range registryEnv {
 		addEnvToPod(pod, key, value)

--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -132,6 +132,8 @@ func TestBuildPod(t *testing.T) {
 			build.imgName,
 			build.storageType,
 			build.dockerBuilderImage,
+			"localhost",
+			"5555",
 			regEnv,
 			build.dockerBuilderImagePullPolicy,
 		)


### PR DESCRIPTION
Dockerbuilder fails pushing images to the registry when --insecure-registry
is turned off because it is not using the registry proxy to push images.

closes https://github.com/deis/dockerbuilder/issues/83