### PR TITLE
test(slugbuilder-cache): add missing test for CACHE_PATH

### DIFF
--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -94,6 +94,7 @@ func TestBuildPod(t *testing.T) {
 
 		checkForEnv(t, pod, "TAR_PATH", build.tarKey)
 		checkForEnv(t, pod, "PUT_PATH", build.putKey)
+		checkForEnv(t, pod, "CACHE_PATH", build.cacheKey)
 
 		if build.buildPack != "" {
 			checkForEnv(t, pod, "BUILDPACK_URL", build.buildPack)


### PR DESCRIPTION
Before, we didn't test if the CACHE_PATH was defined properly.