### PR TITLE
tests(gitreceive): remove duplicated tests

### DIFF
--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -58,10 +58,7 @@ func TestBuildPod(t *testing.T) {
 
 	slugBuilds := []slugBuildCase{
 		{true, "test", "default", emptyEnv, "tar", "put-url", "cache-url", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "put-url", "cache-url", "", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "put-url", "cache-url", "", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "put-url", "cache-url", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "put-url", "cache-url", "buildpack", "", api.PullAlways, ""},
 		{true, "test", "default", emptyEnv, "tar", "put-url", "cache-url", "buildpack", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "put-url", "cache-url", "buildpack", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "put-url", "cache-url", "buildpack", "customimage", api.PullAlways, ""},
@@ -114,10 +111,7 @@ func TestBuildPod(t *testing.T) {
 
 	dockerBuilds := []dockerBuildCase{
 		{true, "test", "default", emptyEnv, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", env, "tar", "", "", api.PullAlways, ""},
-		{true, "test", "default", emptyEnv, "tar", "img", "", api.PullAlways, ""},
 		{true, "test", "default", emptyEnv, "tar", "img", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "img", "", api.PullAlways, ""},
 		{true, "test", "default", env, "tar", "img", "customimage", api.PullAlways, ""},


### PR DESCRIPTION
In the refactor of 67a9adbf9a7f18794106868065a06282c0dda1b6, some things were changed along with these tests, but they were never deduplicated. This should get these out.