### PR TITLE
fix(travis): remove vendor dir from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: generic
 branches:
   only:
     - master
-cache:
-  directories:
-    - vendor
 env:
   DEV_REGISTRY=quay.io
 services:


### PR DESCRIPTION
caching the vendor directory has caused more headaches than actual improvements to CI. Removing the vendor dir from being cached should save us any issues with CI in the future.

refs https://github.com/deis/builder/issues/438

ping @kmala