### PR TITLE
chore(glide.yaml): update controller-sdk-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4b9ed14e1da72a4fa37de99b3a68823bec0693223921508d7d30afbc003dce79
-updated: 2016-10-03T21:03:51.484239108Z
+hash: c998861680184831e71e2d26e15bf0ed190646cc1a7568a685b9a1c4562743cd
+updated: 2016-11-16T04:22:45.554768613Z
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -22,6 +22,8 @@ imports:
   - aws/session
   - private/endpoints
   - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
   - private/protocol/query
   - private/protocol/query/queryutil
   - private/protocol/rest
@@ -30,10 +32,8 @@ imports:
   - private/signer/v4
   - private/waiter
   - service/cloudfront/sign
-  - service/s3
   - service/ecr
-  - private/protocol/jsonrpc
-  - private/protocol/json/jsonutil
+  - service/s3
 - name: github.com/Azure/azure-sdk-for-go
   version: 95361a2573b1fa92a00c5fc2707a80308483c6f9
   subpackages:
@@ -51,7 +51,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/controller-sdk-go
-  version: c71a2e5efa5dea38c8dfb94c11305c2f05c9af9c
+  version: 27bab7c5535de202635877fa7600d5158b91a757
   subpackages:
   - api
   - hooks
@@ -59,25 +59,26 @@ imports:
 - name: github.com/deis/pkg
   version: 00e55bded444eea7fadff398f93152e962a0c338
   subpackages:
-  - time
   - log
   - prettyprint
+  - time
 - name: github.com/docker/distribution
   version: 0afef00d5764404d70f86076f364551657d51de6
   repo: https://github.com/deis/distribution
   vcs: git
   subpackages:
+  - context
+  - registry/client/transport
   - registry/storage/driver
   - registry/storage/driver/azure
+  - registry/storage/driver/base
   - registry/storage/driver/factory
   - registry/storage/driver/gcs
+  - registry/storage/driver/inmemory
   - registry/storage/driver/s3-aws
   - registry/storage/driver/swift
-  - context
-  - registry/storage/driver/base
-  - registry/client/transport
-  - version
   - uuid
+  - version
 - name: github.com/docker/docker
   version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
   subpackages:
@@ -93,8 +94,8 @@ imports:
 - name: github.com/emicklei/go-restful
   version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
   subpackages:
-  - swagger
   - log
+  - swagger
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
@@ -139,7 +140,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: 91921eb4cf999321cdbeebdba5a03555800d493b
+  version: 9aca109c9aec4633fced9717c4a09ecab3d33111
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
@@ -154,12 +155,12 @@ imports:
   version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
   subpackages:
   - libcontainer
+  - libcontainer/cgroups
   - libcontainer/cgroups/fs
   - libcontainer/configs
-  - libcontainer/cgroups
   - libcontainer/system
 - name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
   version: 3b78d7a77f51ccbc364d4bc170920153022cfd08
   subpackages:
@@ -176,7 +177,7 @@ imports:
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
@@ -200,11 +201,11 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
-  - idna
   - http2
-  - trace
   - http2/hpack
+  - idna
   - internal/timeseries
+  - trace
 - name: golang.org/x/oauth2
   version: 045497edb6234273d67dbc25da3f2ddbc4c4cacf
   subpackages:
@@ -213,27 +214,20 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: a263ba8db058568bb9beba166777d9c9dbe75d68
   subpackages:
-  - secure/precis
-  - unicode/norm
-  - cases
-  - runes
-  - secure/bidirule
   - transform
+  - unicode/norm
   - width
-  - language
-  - unicode/bidi
-  - internal/tag
 - name: google.golang.org/api
   version: fceeaa645c4015c833842e6ed6052b2dda667079
   repo: https://code.googlesource.com/google-api-go-client
   vcs: git
   subpackages:
-  - googleapi
-  - storage/v1
-  - googleapi/internal/uritemplates
   - gensupport
+  - googleapi
+  - googleapi/internal/uritemplates
+  - storage/v1
 - name: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
@@ -244,8 +238,8 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
-  - urlfetch
   - internal/urlfetch
+  - urlfetch
 - name: google.golang.org/cloud
   version: 975617b05ea8a58727e6c1a06b6161ff4185a9f2
   subpackages:
@@ -269,78 +263,78 @@ imports:
 - name: k8s.io/kubernetes
   version: 3eed1e3be6848b877ff80a93da3785d9034d0a4f
   subpackages:
-  - pkg/client/unversioned
   - pkg/api
-  - pkg/fields
-  - pkg/labels
-  - pkg/util/wait
-  - pkg/client/cache
-  - pkg/controller/framework
-  - pkg/runtime
-  - pkg/watch
+  - pkg/api/endpoints
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta
+  - pkg/api/pod
+  - pkg/api/resource
+  - pkg/api/service
   - pkg/api/unversioned
+  - pkg/api/util
+  - pkg/api/v1
+  - pkg/api/validation
+  - pkg/apimachinery
   - pkg/apimachinery/registered
+  - pkg/apis/authorization
   - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling
   - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
   - pkg/apis/batch
   - pkg/apis/batch/install
-  - pkg/apis/componentconfig/install
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/metrics/install
-  - pkg/client/restclient
-  - pkg/client/typed/discovery
-  - pkg/util/net
-  - pkg/util/sets
-  - pkg/version
-  - pkg/api/resource
-  - pkg/auth/user
-  - pkg/conversion
-  - pkg/runtime/serializer
-  - pkg/types
-  - pkg/util
-  - pkg/util/intstr
-  - pkg/util/rand
-  - pkg/util/validation
-  - pkg/util/runtime
-  - pkg/conversion/queryparams
-  - pkg/util/errors
-  - pkg/util/validation/field
-  - pkg/api/v1
-  - pkg/apimachinery
-  - pkg/apis/authorization
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling/v1
   - pkg/apis/batch/v1
   - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
   - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
   - pkg/apis/metrics
+  - pkg/apis/metrics/install
   - pkg/apis/metrics/v1alpha1
-  - pkg/api/validation
+  - pkg/auth/user
+  - pkg/capabilities
+  - pkg/client/cache
   - pkg/client/metrics
+  - pkg/client/restclient
   - pkg/client/transport
-  - pkg/watch/json
-  - third_party/forked/reflect
+  - pkg/client/typed/discovery
+  - pkg/client/unversioned
+  - pkg/controller/framework
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/kubelet/qos
+  - pkg/labels
+  - pkg/master/ports
+  - pkg/runtime
+  - pkg/runtime/serializer
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/versioning
-  - pkg/util/integer
-  - pkg/util/parsers
-  - pkg/kubelet/qos
-  - pkg/master/ports
-  - pkg/api/endpoints
-  - pkg/api/pod
-  - pkg/api/service
-  - pkg/api/util
-  - pkg/capabilities
-  - pkg/util/yaml
+  - pkg/types
+  - pkg/util
+  - pkg/util/errors
   - pkg/util/hash
+  - pkg/util/integer
+  - pkg/util/intstr
+  - pkg/util/net
   - pkg/util/net/sets
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - pkg/watch/json
+  - third_party/forked/reflect
 - name: speter.net/go/exp/math/dec/inf
   version: 46a40649338836f5d25521ce343379da79ef2184
   repo: https://github.com/belua/inf

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,4 +42,4 @@ import:
   repo: https://github.com/spf13/pflag
   vcs: git
 - package: github.com/deis/controller-sdk-go
-  version: c71a2e5efa5dea38c8dfb94c11305c2f05c9af9c
+  version: 27bab7c5535de202635877fa7600d5158b91a757


### PR DESCRIPTION
Fixes a double-slash in the /healthz controller URL. See deis/controller-sdk-go#103.