### PR TITLE
chore(glide): bump golang.org/x/crypto to b822463

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c998861680184831e71e2d26e15bf0ed190646cc1a7568a685b9a1c4562743cd
-updated: 2016-11-16T04:22:45.554768613Z
+hash: 39e2281a70017c96dbce58ceb8233243de88d6a8fcc5be7a258591f09a35791e
+updated: 2017-01-18T10:07:17.7689922-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -140,7 +140,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: 9aca109c9aec4633fced9717c4a09ecab3d33111
+  version: 4069f29f08928c54bcb1fdf632b31b1bb54b4fdb
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
@@ -177,7 +177,7 @@ imports:
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/PuerkitoBio/purell
-  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
@@ -193,8 +193,11 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: f7445b17d61953e333441674c2d11e91ae4559d3
+  version: b82246307bd525fde15c1df976318003716bca68
   subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
   - ssh
 - name: golang.org/x/net
   version: c2528b2dd8352441850638a8bb678c2ad056fd3e
@@ -214,9 +217,16 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/text
-  version: a263ba8db058568bb9beba166777d9c9dbe75d68
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
   - transform
+  - unicode/bidi
   - unicode/norm
   - width
 - name: google.golang.org/api

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/gorilla/mux
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - package: golang.org/x/crypto
-  version: f7445b17d61953e333441674c2d11e91ae4559d3
+  version: b82246307bd525fde15c1df976318003716bca68
   subpackages:
   - ssh
 - package: gopkg.in/yaml.v2


### PR DESCRIPTION
closes #462