### PR TITLE
fix(charts): reference registry-proxy on 127.0.0.1

### DIFF
--- a/charts/builder/templates/builder-deployment.yaml
+++ b/charts/builder/templates/builder-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           env:
             # NOTE(bacongobbler): use deis/registry_proxy to work around Docker --insecure-registry requirements
             - name: "DEIS_REGISTRY_SERVICE_HOST"
-              value: "localhost"
+              value: "127.0.0.1"
             - name: "DEIS_REGISTRY_SERVICE_PORT"
               value: "{{ .Values.global.host_port }}"
             - name: "HEALTH_SERVER_PORT"


### PR DESCRIPTION
On some providers, "localhost" is not set up on the host network. explicitly calling the loopback
address fixes this.

See deis/workflow#678