### PR TITLE
fix(Dockerfile): force gunzip of license files

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E1DF1F24 && \
     apt-get clean -y && \
     # package up license files if any by appending to existing tar
     COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
-    gunzip $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    gunzip -f $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
     rm -rf \
         /usr/share/doc \
         /usr/share/man \


### PR DESCRIPTION
I'm still running into issues with `make docker-build` locally. This fixes it.