### PR TITLE
fix(.travis.yml): declare env vars on one line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ branches:
   only:
     - master
 env:
-  DEV_REGISTRY=quay.io
-  DOCKER_BUILD_FLAGS="--pull --no-cache"
+  - DEV_REGISTRY=quay.io DOCKER_BUILD_FLAGS="--pull --no-cache"
 services:
   - docker
 sudo: required


### PR DESCRIPTION
Without this change, Travis CI runs a separate [job for each environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item), which was unintended.