### PR TITLE
Add pod selector for builder job

### DIFF
--- a/charts/builder/templates/builder-deployment.yaml
+++ b/charts/builder/templates/builder-deployment.yaml
@@ -94,6 +94,10 @@ spec:
                 secretKeyRef:
                   name: builder-key-auth
                   key: builder-key
+{{- if (.Values.builder_pod_node_selector) }}
+            - name: BUILDER_POD_NODE_SELECTOR
+              value: {{.Values.builder_pod_node_selector}}
+{{- end}}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/builder/values.yaml
+++ b/charts/builder/values.yaml
@@ -3,4 +3,4 @@ pull_policy: "Always"
 docker_tag: canary
 # limits_cpu: "100m"
 # limits_memory: "50Mi"
-# builder_pod_node_selector: "cloud.google.com/gke-nodepool=builder"
+# builder_pod_node_selector: "disk:ssd"

--- a/charts/builder/values.yaml
+++ b/charts/builder/values.yaml
@@ -3,3 +3,4 @@ pull_policy: "Always"
 docker_tag: canary
 # limits_cpu: "100m"
 # limits_memory: "50Mi"
+# builder_pod_node_selector: "cloud.google.com/gke-nodepool=builder"

--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -1,7 +1,6 @@
 package gitreceive
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -330,13 +329,12 @@ func build(
 func buildBuilderPodNodeSelector(config string) (map[string]string, error) {
 	selector := make(map[string]string)
 	if config != "" {
-		line := bufio.NewScanner(strings.NewReader(config))
-		for line.Scan() {
-			splits := strings.Split(line.Text(), "=")
-			if len(splits) != 2 {
+		for _, line := range strings.Split(config, ",") {
+			param := strings.Split(line, ":")
+			if len(param) != 2 {
 				return nil, fmt.Errorf("Invalid BuilderPodNodeSelector value format: %s", config)
 			}
-			selector[splits[0]] = splits[1]
+			selector[strings.TrimSpace(param[0])] = strings.TrimSpace(param[1])
 		}
 	}
 	return selector, nil

--- a/pkg/gitreceive/build_test.go
+++ b/pkg/gitreceive/build_test.go
@@ -237,8 +237,9 @@ func TestBuildBuilderPodNodeSelector(t *testing.T) {
 
 	cazes := []podSelectorBuildCase{
 		{"", emptyNodeSelector},
-		{"pool=worker", map[string]string{"pool": "worker"}},
-		{"pool=worker\nnetwork=fast", map[string]string{"pool": "worker", "network": "fast"}},
+		{"pool:worker", map[string]string{"pool": "worker"}},
+		{"pool:worker,network:fast", map[string]string{"pool": "worker", "network": "fast"}},
+		{"pool:worker ,network:fast, disk:ssd", map[string]string{"pool": "worker", "network": "fast", "disk": "ssd"}},
 	}
 
 	for _, caze := range cazes {
@@ -247,6 +248,6 @@ func TestBuildBuilderPodNodeSelector(t *testing.T) {
 		assert.Equal(t, output, caze.Output, "pod selector")
 	}
 
-	_, err := buildBuilderPodNodeSelector("failtest")
-	assert.ExistsErr(t, err, "fail test")
+	_, err := buildBuilderPodNodeSelector("invalidformat")
+	assert.ExistsErr(t, err, "invalid format")
 }

--- a/pkg/gitreceive/build_test.go
+++ b/pkg/gitreceive/build_test.go
@@ -31,6 +31,11 @@ type testJSONStruct struct {
 	Foo string `json:"foo,omitempty"`
 }
 
+type podSelectorBuildCase struct {
+	Config string
+	Output map[string]string
+}
+
 func TestBuild(t *testing.T) {
 	config := &Config{}
 	env := sys.NewFakeEnv()
@@ -225,4 +230,23 @@ func TestRunCmd(t *testing.T) {
 	if output != expected {
 		t.Errorf("expected '%s', got '%s'", expected, output)
 	}
+}
+
+func TestBuildBuilderPodNodeSelector(t *testing.T) {
+	emptyNodeSelector := make(map[string]string)
+
+	cazes := []podSelectorBuildCase{
+		{"", emptyNodeSelector},
+		{"pool=worker", map[string]string{"pool": "worker"}},
+		{"pool=worker\nnetwork=fast", map[string]string{"pool": "worker", "network": "fast"}},
+	}
+
+	for _, caze := range cazes {
+		output, err := buildBuilderPodNodeSelector(caze.Config)
+		assert.Nil(t, err, "error")
+		assert.Equal(t, output, caze.Output, "pod selector")
+	}
+
+	_, err := buildBuilderPodNodeSelector("failtest")
+	assert.ExistsErr(t, err, "fail test")
 }

--- a/pkg/gitreceive/config.go
+++ b/pkg/gitreceive/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	SlugBuilderImagePullPolicy    string `envconfig:"SLUG_BUILDER_IMAGE_PULL_POLICY" default:"Always"`
 	DockerBuilderImagePullPolicy  string `envconfig:"DOCKER_BUILDER_IMAGE_PULL_POLICY" default:"Always"`
 	StorageType                   string `envconfig:"BUILDER_STORAGE" default:"minio"`
+	BuilderPodNodeSelector        string `envconfig:"BUILDER_POD_NODE_SELECTOR" default:""`
 }
 
 // App returns the application name represented by c. The app name is the same as c.Repository

--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -55,9 +55,10 @@ func dockerBuilderPod(
 	registryPort string,
 	registryEnv map[string]string,
 	pullPolicy api.PullPolicy,
+	nodeSelector map[string]string,
 ) *api.Pod {
 
-	pod := buildPod(debug, name, namespace, pullPolicy, env)
+	pod := buildPod(debug, name, namespace, pullPolicy, nodeSelector, env)
 
 	// inject application envvars as a special envvar which will be handled by dockerbuilder to
 	// inject them as build-time variables.
@@ -115,9 +116,10 @@ func slugbuilderPod(
 	storageType,
 	image string,
 	pullPolicy api.PullPolicy,
+	nodeSelector map[string]string,
 ) *api.Pod {
 
-	pod := buildPod(debug, name, namespace, pullPolicy, nil)
+	pod := buildPod(debug, name, namespace, pullPolicy, nodeSelector, nil)
 
 	pod.Spec.Volumes = append(pod.Spec.Volumes, api.Volume{
 		Name: envSecretName,
@@ -159,6 +161,7 @@ func buildPod(
 	name,
 	namespace string,
 	pullPolicy api.PullPolicy,
+	nodeSelector map[string]string,
 	env map[string]interface{}) api.Pod {
 
 	pod := api.Pod{
@@ -204,6 +207,10 @@ func buildPod(
 				Value: fmt.Sprintf("%v", v),
 			})
 		}
+	}
+
+	if len(nodeSelector) > 0 {
+		pod.Spec.NodeSelector = nodeSelector
 	}
 
 	if debug {


### PR DESCRIPTION
add a new environment variable to inject builder job node selector.
format `BUILDER_POD_NODE_SELECTOR` = `network:fast,disk:ssd`

Closes https://github.com/deis/builder/issues/410
docs https://github.com/deis/workflow/pull/770