### PR TITLE
ref(k8s_util): make users opt into DOCKER_BUILD_ARGS

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -67,8 +67,10 @@ func dockerBuilderPod(
 	// {"KEY": "value"}
 	//
 	// So we need to translate the map into json.
-	dockerBuildArgs, _ := json.Marshal(env)
-	addEnvToPod(pod, "DOCKER_BUILD_ARGS", string(dockerBuildArgs))
+	if _, ok := env["DEIS_DOCKER_BUILD_ARGS_ENABLED"]; ok {
+		dockerBuildArgs, _ := json.Marshal(env)
+		addEnvToPod(pod, "DOCKER_BUILD_ARGS", string(dockerBuildArgs))
+	}
 
 	pod.Spec.Containers[0].Name = dockerBuilderName
 	pod.Spec.Containers[0].Image = image

--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -61,6 +61,9 @@ func TestBuildPod(t *testing.T) {
 
 	env := make(map[string]interface{})
 	env["KEY"] = "VALUE"
+	buildArgsEnv := make(map[string]interface{})
+	buildArgsEnv["DEIS_DOCKER_BUILD_ARGS_ENABLED"] = "1"
+	buildArgsEnv["KEY"] = "VALUE"
 	envSecretName := "test-build-env"
 	var pod *api.Pod
 
@@ -149,6 +152,7 @@ func TestBuildPod(t *testing.T) {
 		{true, "test", "default", env, "tar", "deadbeef", "img", "customimage", api.PullAlways, "", emptyNodeSelector},
 		{true, "test", "default", env, "tar", "deadbeef", "img", "customimage", api.PullIfNotPresent, "", emptyNodeSelector},
 		{true, "test", "default", env, "tar", "deadbeef", "img", "customimage", api.PullNever, "", nil},
+		{true, "test", "default", buildArgsEnv, "tar", "deadbeef", "img", "customimage", api.PullIfNotPresent, "", emptyNodeSelector},
 	}
 	regEnv := map[string]string{"REG_LOC": "on-cluster"}
 	for _, build := range dockerBuilds {
@@ -180,6 +184,9 @@ func TestBuildPod(t *testing.T) {
 		checkForEnv(t, pod, "TAR_PATH", build.tarKey)
 		checkForEnv(t, pod, "IMG_NAME", build.imgName)
 		checkForEnv(t, pod, "REG_LOC", "on-cluster")
+		if _, ok := build.env["DEIS_DOCKER_BUILD_ARGS_ENABLED"]; ok {
+			checkForEnv(t, pod, "DOCKER_BUILD_ARGS", `{"DEIS_DOCKER_BUILD_ARGS_ENABLED":"1","KEY":"VALUE"}`)
+		}
 		if build.dockerBuilderImage != "" {
 			if pod.Spec.Containers[0].Image != build.dockerBuilderImage {
 				t.Errorf("expected %v but returned %v", build.dockerBuilderImage, pod.Spec.Containers[0].Image)


### PR DESCRIPTION
injecting build args into the image by default has caused a significant performance penalty for
applications not utilizing the build args. Making it an opt-in feature flag via `deis config:set DEIS_DOCKER_BUILD_ARGS_ENABLED=1` allows users to inject their environment into their Dockerfiles, but they must opt into that performance penalty.

I feel like there's been enough concerns about turning this feature flag on by default in v2.12.0 that we should consider cutting a v2.12.1 with this fix.