### PR TITLE
fix(gitreceive): fix checkForEnv logic

### DIFF
--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -204,7 +204,7 @@ func checkForEnv(t *testing.T, pod *api.Pod, key, expVal string) {
 	if err != nil {
 		t.Errorf("%v", err)
 	}
-	if val != val {
+	if expVal != val {
 		t.Errorf("expected %v but returned %v ", expVal, val)
 	}
 }


### PR DESCRIPTION
val != val is clearly never going to fail. Changed
to expVal != val