### PR TITLE
fix(builder): truncate slugbuilder and dockerbuilder pod name length

### DIFF
--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -33,11 +33,21 @@ const (
 
 func dockerBuilderPodName(appName, shortSha string) string {
 	uid := uuid.New()[:8]
+	// NOTE(bacongobbler): pod names cannot exceed 63 characters in length, so we truncate
+	// the application name to stay under that limit when adding all the extra metadata to the name
+	if len(appName) > 33 {
+		appName = appName[:33]
+	}
 	return fmt.Sprintf("dockerbuild-%s-%s-%s", appName, shortSha, uid)
 }
 
 func slugBuilderPodName(appName, shortSha string) string {
 	uid := uuid.New()[:8]
+	// NOTE(bacongobbler): pod names cannot exceed 63 characters in length, so we truncate
+	// the application name to stay under that limit when adding all the extra metadata to the name
+	if len(appName) > 35 {
+		appName = appName[:35]
+	}
 	return fmt.Sprintf("slugbuild-%s-%s-%s", appName, shortSha, uid)
 }
 

--- a/pkg/gitreceive/k8s_util_test.go
+++ b/pkg/gitreceive/k8s_util_test.go
@@ -15,14 +15,30 @@ import (
 func TestDockerBuilderPodName(t *testing.T) {
 	name := dockerBuilderPodName("demo", "12345678")
 	if !strings.HasPrefix(name, "dockerbuild-demo-12345678-") {
-		t.Fatalf("expected pod name dockerbuild-demo-12345678-*, got %s", name)
+		t.Errorf("expected pod name dockerbuild-demo-12345678-*, got %s", name)
+	}
+
+	name = dockerBuilderPodName("this-name-has-more-than-24-characters-in-length", "12345678")
+	if !strings.HasPrefix(name, "dockerbuild-this-name-has-more-than-24-charac-12345678-") {
+		t.Errorf("expected pod name dockerbuild-this-name-has-more-than-24-charac-12345678-*, got %s", name)
+	}
+	if len(name) > 63 {
+		t.Errorf("expected dockerbuilder pod name length to be <= 63 characters in length, got %d", len(name))
 	}
 }
 
 func TestSlugBuilderPodName(t *testing.T) {
 	name := slugBuilderPodName("demo", "12345678")
 	if !strings.HasPrefix(name, "slugbuild-demo-12345678-") {
-		t.Fatalf("expected pod name slugbuild-demo-12345678-*, got %s", name)
+		t.Errorf("expected pod name slugbuild-demo-12345678-*, got %s", name)
+	}
+
+	name = slugBuilderPodName("this-name-has-more-than-24-characters-in-length", "12345678")
+	if !strings.HasPrefix(name, "slugbuild-this-name-has-more-than-24-characte-12345678-") {
+		t.Errorf("expected pod name slugbuild-this-name-has-more-than-24-characte-12345678-*, got %s", name)
+	}
+	if len(name) > 63 {
+		t.Errorf("expected slugbuilder pod name length to be <= 63 characters in length, got %d", len(name))
 	}
 }
 


### PR DESCRIPTION
kubernetes has a name length limit of 63 characters. We must truncate the name such that it stays
below that limit with the new app name length bump.

closes #504