### PR TITLE
RBAC support

### DIFF
--- a/charts/builder/templates/_helpers.tmpl
+++ b/charts/builder/templates/_helpers.tmpl
@@ -1,0 +1,10 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/builder/templates/builder-clusterrole.yaml
+++ b/charts/builder/templates/builder-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRole
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-builder
+  labels:
+    app: deis-builder
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+{{- end -}}
+{{- end -}}

--- a/charts/builder/templates/builder-clusterrolebinding.yaml
+++ b/charts/builder/templates/builder-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-builder
+  labels:
+    app: deis-builder
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deis:deis-builder
+subjects:
+- kind: ServiceAccount
+  name: deis-builder
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/builder/templates/builder-role.yaml
+++ b/charts/builder/templates/builder-role.yaml
@@ -1,0 +1,21 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: Role
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis-builder
+  labels:
+    app: deis-builder
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "update", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+{{- end -}}
+{{- end -}}

--- a/charts/builder/templates/builder-rolebinding.yaml
+++ b/charts/builder/templates/builder-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: RoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis-builder
+  labels:
+    app: deis-builder
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deis-builder
+subjects:
+- kind: ServiceAccount
+  name: deis-builder
+{{- end -}}
+{{- end -}}

--- a/charts/builder/values.yaml
+++ b/charts/builder/values.yaml
@@ -12,3 +12,5 @@ global:
   # - true: The deis controller will now create Kubernetes ingress rules for each app, and ingress rules will automatically be created for the controller itself.
   # - false: The default mode, and the default behavior of Deis workflow.
   experimental_native_ingress: false
+  # Role-Based Access Control for Kubernetes >= 1.5
+  use_rbac: false


### PR DESCRIPTION
With this change deis-builder became available to work in **RBAC**-only clusters

Works with both Kubernetes 1.5 and 1.6 (see `templates/_helpers.tmpl` for details)
Actually tested with 1.5.7 and 1.6.2

Role allows `deis-builder`:
- `secrets`: `create`, `update` and `delete`
- `pods`: `get`, `list`, `watch` and `create`
- `pods/log:` `get`

ClusterRole allows `deis-builder`:
- `namespaces`: `list`