### PR TITLE
fix(builder): Remove RC4 Ciphers

### DIFF
--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -96,6 +96,7 @@ func Configure(cnf *Config) (*ssh.ServerConfig, error) {
 		log.Debug("Parsed host key %s.", path)
 		cfg.AddHostKey(hk)
 	}
+	cfg.Config.Ciphers = []string{"aes128-ctr","aes192-ctr","aes256-ctr","aes128-gcm@openssh.com"}
 	return cfg, nil
 }
 

--- a/pkg/sshd/server.go
+++ b/pkg/sshd/server.go
@@ -96,7 +96,7 @@ func Configure(cnf *Config) (*ssh.ServerConfig, error) {
 		log.Debug("Parsed host key %s.", path)
 		cfg.AddHostKey(hk)
 	}
-	cfg.Config.Ciphers = []string{"aes128-ctr","aes192-ctr","aes256-ctr","aes128-gcm@openssh.com"}
+	cfg.Config.Ciphers = []string{"aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-gcm@openssh.com"}
 	return cfg, nil
 }
 


### PR DESCRIPTION
RC4 Ciphers are known to be weaker. This PR removes them, leaving all other default ciphers in place. https://www.rfc-editor.org/rfc/rfc7465.txt